### PR TITLE
DM-11118: Build stubbed out verify_ap

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,33 @@
 This package manages end-to-end testing and metric generation for the LSST DM Alert Production pipeline. Metrics are tested against both project- and lower-level requirements, and will be deliverable to the SQuaSH metrics service.
 
 `ap_verify` is part of the LSST Science Pipelines. You can learn how to install the Pipelines at https://pipelines.lsst.io/install/index.html.
+
+## Configuration
+
+`ap_verify` is configured from `config/dataset_config.yaml`. The file currently must have a single dictionary named `datasets`, which maps from user-visible dataset names to the eups package that implements them (see `Setting Up a Package`, below). Other configuration options may be added in the future.
+
+### Setting Up a Package
+
+`ap_verify` requires that all data be in a [dataset package](https://github.com/lsst-dm/ap_verify_dataset_template). It will create a workspace modeled after the package's `data` directory, then process any data found in the `raw` and `ref_cats` in the new workspace. Anything placed in `data` will be copied to a `ap_verify` run's workspace as-is, and must at least include a `_mapper` file naming the CameraMapper for the data.
+
+The dataset package must work with eups, and must be registered in `config/dataset_config.yaml` in order for `ap_verify` to support it. `ap_verify` will use `eups setup` to prepare the dataset package and any dependencies; typically, they will include the `obs_` package for the instrument that took the data.
+
+## Running ap_verify
+
+A basic run on HiTS data:
+
+    python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --output workspace/hits/ --dataIdString "visit=54123"
+
+This will create a workspace (a Butler repository) in `workspace/hits` based on `<hits-data>/data/`, ingest the HiTS data into it, then run visit 54123 through the entire AP pipeline. `ap_verify` also supports the `--rerun` system:
+
+    python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --rerun run1 --dataIdString "visit=54123"
+
+This will create a workspace in `<hits-data>/rerun/run1/`. Since datasets are not, in general, repositories, many of the complexities of `--rerun` for Tasks (e.g., always using the highest-level repository) do not apply. In addition, the `--rerun` argument does not support input directories; the input for `ap_verify` will always be determined by the `--dataset`.
+
+### Optional Arguments
+
+`--silent`: Normally, `ap_verify` submits measurements to SQuaSH for quality tracking. This argument disables reporting for test runs. `ap_verify` will dump measurements to `ap_verify.verify.json` regardless of whether this flag is set.
+
+`-j, --processes`: Specify a particular degree of parallelism. Like in Tasks, this argument may be taken at face value with no intelligent thread management.
+
+`-h, --help, --version`: These arguments print a brief usage guide and the program version, respectively.

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,4 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+scripts.BasicSConstruct("ap_verify")
+

--- a/config/dataset_config.yaml
+++ b/config/dataset_config.yaml
@@ -1,0 +1,5 @@
+---
+datasets:
+    HiTS2015: ap_verify_hits2015
+...
+

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -1,0 +1,158 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Command-line program for running and analyzing AP pipeline.
+
+In addition to containing ap_verify's main function, this module manages
+command-line argument parsing.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = []
+
+import argparse
+import os
+import re
+
+import lsst.log
+from lsst.ap.verify.dataset import Dataset
+from lsst.ap.verify.metrics import MetricsParser, check_squash_ready, AutoJob
+from lsst.ap.verify.appipe import ApPipeParser, ApPipe
+
+
+class _VerifyApParser(argparse.ArgumentParser):
+    """An argument parser for data needed by this script.
+    """
+
+    def __init__(self):
+        argparse.ArgumentParser.__init__(
+            self,
+            description='Executes the LSST DM AP pipeline and analyzes its performance using metrics.',
+            epilog='',
+            parents=[ApPipeParser(), MetricsParser()],
+            add_help=True)
+        self.add_argument('--dataset', choices=Dataset.get_supported_datasets(), required=True,
+                          help='The source of data to pass through the pipeline.')
+
+        output = self.add_mutually_exclusive_group(required=True)
+        output.add_argument('--output', help='The location of the repository to use for program output.')
+        output.add_argument(
+            '--rerun', metavar='OUTPUT',
+            type=_FormattedType('[^:]+',
+                                'Invalid name "%s"; ap_verify supports only output reruns. '
+                                'You have entered something that appears to be of the form INPUT:OUTPUT. '
+                                'Please specify only OUTPUT.'),
+            help='The location of the repository to use for program output, as DATASET/rerun/OUTPUT')
+
+        self.add_argument('--version', action='version', version='%(prog)s 0.1.0')
+
+
+class _FormattedType:
+    """An argparse type converter that requires strings in a particular format.
+
+    Leaves the input as a string if it matches, else raises ArgumentTypeError.
+
+    Parameters
+    ----------
+    fmt: `str`
+        A regular expression that values must satisfy to be accepted. The *entire* string must match the
+        expression in order to pass.
+    msg: `str`
+        An error string to display for invalid values. The first "%s" shall be filled with the
+        invalid argument.
+    """
+    def __init__(self, fmt, msg='"%s" does not have the expected format.'):
+        full_format = fmt
+        if not full_format.startswith('^'):
+            full_format = '^' + full_format
+        if not full_format.endswith('$'):
+            full_format += '$'
+        self._format = re.compile(full_format)
+        self._message = msg
+
+    def __call__(self, value):
+        if self._format.match(value):
+            return value
+        else:
+            raise argparse.ArgumentTypeError(self._message % value)
+
+
+def _get_output_dir(input_dir, output_arg, rerun_arg):
+    """Choose an output directory based on program arguments.
+
+    Parameters
+    ----------
+    input_dir: `str`
+        The root directory of the input dataset.
+    output_arg: `str`
+        The directory given using the `--output` command line argument.
+    rerun_arg: `str`
+        The subdirectory given using the `--rerun` command line argument. Must
+        be relative to `input_rerun`.
+
+    Raises
+    ------
+    `ValueError`:
+        Neither `output_arg` nor `rerun_arg` is None, or both are.
+    """
+    if output_arg and rerun_arg:
+        raise ValueError('Cannot provide both --output and --rerun.')
+    if not output_arg and not rerun_arg:
+        raise ValueError('Must provide either --output or --rerun.')
+    if output_arg:
+        return output_arg
+    else:
+        return os.path.join(input_dir, "rerun", rerun_arg)
+
+
+def _measure_final_properties(metrics_job):
+    """Measure any metrics that apply to the final result of the AP pipeline,
+    rather than to a particular processing stage.
+
+    Parameters
+    ----------
+    metrics_job: `verify.Job`
+        The Job object to which to add any metric measurements made.
+    """
+    pass
+
+
+if __name__ == '__main__':
+    lsst.log.configure()
+    log = lsst.log.Log.getLogger('ap.verify.ap_verify.main')
+    # TODO: what is LSST's policy on exceptions escaping into main()?
+    args = _VerifyApParser().parse_args()
+    check_squash_ready(args)
+    log.debug('Command-line arguments: %s', args)
+
+    test_data = Dataset(args.dataset)
+    log.info('Dataset %s set up.', args.dataset)
+    output = _get_output_dir(test_data.dataset_root, args.output, args.rerun)
+    test_data.make_output_repo(output)
+    log.info('Output repo at %s created.', output)
+
+    with AutoJob(args) as job:
+        log.info('Running pipeline...')
+        pipeline = ApPipe(test_data, output, args)
+        pipeline.run(job)
+        _measure_final_properties(job)

--- a/python/lsst/ap/verify/appipe.py
+++ b/python/lsst/ap/verify/appipe.py
@@ -1,0 +1,162 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["ApPipeParser", "ApPipe"]
+
+import argparse
+
+import lsst.log
+from lsst.ap.verify.dataset import Dataset
+from lsst.ap.verify.pipeline import Pipeline
+
+
+class ApPipeParser(argparse.ArgumentParser):
+    """An argument parser for data needed by ap_pipe activities.
+
+    This parser is not complete, and is designed to be passed to another parser
+    using the `parent` parameter.
+    """
+
+    def __init__(self):
+        # Help and documentation will be handled by main program's parser
+        argparse.ArgumentParser.__init__(self, add_help=False)
+        self.add_argument('--dataIdString', dest='dataId', required=True,
+                          help='An identifier for the data to process. '
+                          'May not support all features of a Butler dataId; '
+                          'see the ap_pipe documentation for details.')
+        self.add_argument("-j", "--processes", default=1, type=int, help="Number of processes to use")
+
+
+class ApPipe(Pipeline):
+    """Wrapper for `lsst.ap.pipe` that executes all steps through source
+    association.
+
+    This class is not designed to have subclasses.
+
+    Parameters
+    ----------
+    dataset: `dataset.Dataset`
+        The dataset on which the pipeline will be run.
+    working_dir: `str`
+        The repository in which temporary products will be created. Must be
+        compatible with `dataset`.
+    parsed_cmd_line: `argparse.Namespace`
+        Command-line arguments, including all arguments supported by `ApPipeParser`.
+    """
+
+    def __init__(self, dataset, working_dir, parsed_cmd_line):
+        Pipeline.__init__(self, dataset, working_dir)
+        self._dataId = parsed_cmd_line.dataId
+        self._parallelization = parsed_cmd_line.processes
+
+    def _ingest_raws(self):
+        """Ingest the raw data for use by LSST.
+
+        The original data directory shall not be modified.
+        """
+        # use self.dataset and self.repo
+        raise NotImplementedError
+
+    def _ingest_calibs(self):
+        """Ingest the raw calibrations for use by LSST.
+
+        The original calibration directory shall not be modified.
+        """
+        # use self.dataset and self.repo
+        raise NotImplementedError
+
+    def _ingest_templates(self):
+        """Ingest precomputed templates for use by LSST.
+
+        The templates may be either LSST `calexp` or LSST
+        `deepCoadd_psfMatchedWarp`. The original template directory shall not
+        be modified.
+        """
+        # use self.dataset and self.repo
+        raise NotImplementedError
+
+    def _process(self, metrics_job):
+        """Run single-frame processing on a dataset.
+
+        Parameters
+        ----------
+        metrics_job: `verify.Job`
+            The Job object to which to add any metric measurements made.
+        """
+        # use self.repo, self._dataId, self._parallelization
+        raise NotImplementedError
+
+    def _difference(self, metrics_job):
+        """Run image differencing on a dataset.
+
+        Parameters
+        ----------
+        metrics_job: `verify.Job`
+            The Job object to which to add any metric measurements made.
+        """
+        # use self.repo, self._dataId, self._parallelization
+        raise NotImplementedError
+
+    def _associate(self, metrics_job):
+        """Run source association on a dataset.
+
+        Parameters
+        ----------
+        metrics_job: `verify.Job`
+            The Job object to which to add any metric measurements made.
+        """
+        # use self.repo, self._parallelization
+        raise NotImplementedError
+
+    def _post_process(self):
+        """Run post-processing on a dataset.
+
+        This step is called the "afterburner" in some design documents.
+        """
+        # use self.repo
+        pass
+
+    def run(self, metrics_job):
+        """Run `ap_pipe` on this object's dataset.
+
+        Parameters
+        ----------
+        metrics_job: `verify.Job`
+            The Job object to which to add any metric measurements made.
+        """
+        log = lsst.log.Log.getLogger('ap.verify.appipe.ApPipe.run')
+
+        self._ingest_raws()
+        self._ingest_calibs()
+        self._ingest_templates()
+        log.info('Data ingested')
+
+        self._process(metrics_job)
+        log.info('Single-frame processing complete')
+        self._difference(metrics_job)
+        log.info('Image differencing complete')
+        self._associate(metrics_job)
+        log.info('Source association complete')
+        self._post_process()
+        log.info('Pipeline complete')

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -1,0 +1,218 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+from future.utils import raise_from
+import os
+import shutil
+
+from eups import Eups
+import yaml
+
+from lsst.utils import getPackageDir
+
+
+class Dataset(object):
+    """A dataset supported by ap_verify.
+
+    Any object of this class is guaranteed to represent a ready-for-use
+    dataset, barring concurrent changes to the file system or EUPS operations.
+    Constructing a Dataset does not create a compatible output repository(ies),
+    which can be done by calling `makeOutputRepo`.
+
+    Parameters
+    ----------
+    dataset_id : `str`
+       A tag identifying the dataset.
+
+    Raises
+    ------
+    `RuntimeError`:
+        `dataset_id` exists, but is not correctly organized or incomplete
+    `ValueError`:
+        `dataset_id` is not a recognized dataset. No side effects if this
+        exception is raised.
+    """
+
+    def __init__(self, dataset_id):
+        try:
+            dataset_package = self._getDatasetInfo()[dataset_id]
+        except KeyError:
+            raise ValueError('Unsupported dataset: ' + dataset_id)
+
+        self._data_root_dir = getPackageDir(dataset_package)
+        self._validate_package()
+
+        self._init_package(dataset_package)
+
+    def _init_package(self, name):
+        """Load the package backing this dataset.
+
+        Parameters
+        ----------
+        name : `str`
+           The EUPS package identifier for the desired package.
+        """
+        Eups().setup(name)
+
+    @staticmethod
+    def get_supported_datasets():
+        """The dataset IDs that can be passed to this class's constructor.
+
+        Returns
+        -------
+        A set of strings of valid tags
+
+        Raises
+        ------
+        `IoError`:
+            if the config file does not exist or is not readable
+        `RuntimeError`:
+            if the config file exists, but does not contain the expected data
+        """
+        return Dataset._getDatasetInfo().keys()
+
+    @staticmethod
+    def _getDatasetInfo():
+        """Return external data on supported datasets.
+
+        If an exception is raised, the program state shall be unchanged.
+
+        Returns
+        -------
+        A map from dataset IDs to package names.
+
+        Raises
+        ------
+        `IoError`:
+            the config file does not exist or is not readable
+        `RuntimeError`:
+            the config file exists, but does not contain the expected data
+        """
+        if not hasattr(Dataset, '_dataset_config'):
+            try:
+                yaml_file = os.path.join(getPackageDir('ap_verify'), 'config/dataset_config.yaml')
+                with open(yaml_file, 'r') as config:
+                    dataset_map = yaml.safe_load(config)['datasets']
+                if not isinstance(dataset_map, dict):
+                    raise TypeError('`datasets` is not a dictionary')
+
+                Dataset._dataset_config = dataset_map
+            except (KeyError, TypeError, yaml.YAMLError) as e:
+                raise_from(RuntimeError('Invalid config file.'), e)
+
+        return Dataset._dataset_config
+
+    @property
+    def dataset_root(self):
+        """The parent directory containing everything related to the dataset.
+
+        Returns
+        -------
+        a string giving the location of the base directory
+        """
+        return self._data_root_dir
+
+    @property
+    def data_location(self):
+        """The directory containing the "raw" input data.
+
+        Returns
+        -------
+        a string giving the location of the top-level directory for telescope output files
+        """
+        return os.path.join(self.dataset_root, 'raw')
+
+    @property
+    def calib_location(self):
+        """The directory containing the calibration data.
+
+        Returns
+        -------
+        a string giving the location of the top-level directory for master calibration files
+        """
+        return os.path.join(self.dataset_root, 'calib')
+
+    @property
+    def template_location(self):
+        """The directory containing the image subtraction templates.
+
+        Returns
+        -------
+        a string giving the location of the top-level directory for precomputed templates
+        """
+        return os.path.join(self.dataset_root, 'templates')
+
+    @property
+    def _stub_input_repo(self):
+        """The directory containing the data set's input stub.
+
+        Returns
+        -------
+        a string giving the location of the stub input repo
+        """
+        return os.path.join(self.dataset_root, 'data')
+
+    def _validate_package(self):
+        """Confirm that the dataset directory satisfies all assumptions.
+
+        Requires that self._data_root_dir has been initialized.
+
+        Raises
+        ------
+        `RuntimeError`:
+            if any problems are found with the package
+        """
+        if not os.path.exists(self.dataset_root):
+            raise RuntimeError('Could not find dataset at ' + self.dataset_root)
+        if not os.path.exists(self.data_location):
+            raise RuntimeError('Dataset at ' + self.dataset_root + 'is missing data directory')
+        if not os.path.exists(self.calib_location):
+            raise RuntimeError('Dataset at ' + self.dataset_root + 'is missing calibration directory')
+        # Template directory might not be subdirectory of self.dataset_root
+        if not os.path.exists(self.template_location):
+            raise RuntimeError('Dataset is missing template directory at ' + self.template_location)
+        if not os.path.exists(self._stub_input_repo):
+            raise RuntimeError('Dataset at ' + self.dataset_root + 'is missing stub repo')
+        if not os.path.exists(os.path.join(self._stub_input_repo, '_mapper')):
+            raise RuntimeError('Stub repo at ' + self._stub_input_repo + 'is missing mapper file')
+
+    def make_output_repo(self, output_dir):
+        """Set up a directory as an output repository compatible with this dataset.
+
+        Parameters
+        ----------
+        output_dir: `str`
+            The directory where the output repository will be created. Must be
+            empty or non-existent.
+        """
+        if os.path.exists(output_dir):
+            if not os.path.isdir(output_dir):
+                raise IOError(output_dir + 'is not a directory')
+            if os.listdir(output_dir):
+                raise IOError(output_dir + 'is already occupied')
+
+            # copytree does not allow empty destination directories
+            shutil.rmtree(output_dir)
+
+        shutil.copytree(self._stub_input_repo, output_dir)

--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -1,0 +1,164 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Verification metrics handling for the AP pipeline.
+
+This module handles metrics loading and export (via the AutoJob class), but not
+processing of individual measurements. Measurements are handled in the
+ap_verify module or in the appropriate pipeline step, as appropriate.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["AutoJob", "MetricsParser", "check_squash_ready"]
+
+import argparse
+import os
+
+import lsst.log
+import lsst.verify
+
+# Standard environment variables for interoperating with lsst.verify.dispatch_verify.py
+_ENV_USER = 'SQUASH_USER'
+_ENV_PASSWORD = 'SQUASH_PASSWORD'
+_ENV_URL = 'SQUASH_URL'
+_SQUASH_DEFAULT_URL = 'https://squash.lsst.codes/dashboard/api'
+
+
+def check_squash_ready(parsed_cmd_line):
+    """Test whether the program has everything it needs for the SQuaSH API.
+
+    As a special case, this function never raises if `parsed_cmd_line.submit_metrics` is unset.
+
+    Parameters
+    ----------
+    parsed_cmd_line: `argparse.Namespace`
+        Command-line arguments, including all arguments supported by `MetricsParser`.
+
+    Raises
+    ------
+    `RuntimeError`
+        A configuration problem would prevent SQuaSH features from being used.
+    """
+    if parsed_cmd_line.submit_metrics:
+        for var in (_ENV_USER, _ENV_PASSWORD):
+            if var not in os.environ:
+                raise RuntimeError('Need to define environment variable "%s" to use SQuaSH; '
+                                   'pass --silent to skip.' % var)
+
+
+class MetricsParser(argparse.ArgumentParser):
+    """An argument parser for data needed by metrics activities.
+
+    This parser is not complete, and is designed to be passed to another parser
+    using the `parent` parameter.
+    """
+
+    def __init__(self):
+        # Help and documentation will be handled by main program's parser
+        argparse.ArgumentParser.__init__(self, add_help=False)
+        self.add_argument('--silent', dest='submit_metrics', action='store_false',
+                          help='Do NOT submit metrics to SQuaSH (not yet implemented).')
+        # Config info we don't want on the command line
+        self.set_defaults(user=os.getenv(_ENV_USER), password=os.getenv(_ENV_PASSWORD),
+                          squash_url=os.getenv(_ENV_URL, _SQUASH_DEFAULT_URL))
+
+
+class AutoJob:
+    """A wrapper for an lsst.verify.Job that automatically handles
+    initialization and shutdown.
+
+    When used in a `with... as...` statement, the wrapper assigns the
+    underlying job to the `as` target.
+
+    This object shall always attempt to dump metrics to disk, but shall only
+    submit to SQuaSH if the program ran without errors.
+
+    Parameters
+    ----------
+    parsed_cmd_line: `argparse.Namespace`
+        Command-line arguments, including all arguments supported by `MetricsParser`.
+    """
+    def __init__(self, args):
+        self._job = lsst.verify.Job.load_metrics_package()
+        # TODO: add Job metadata (camera, filter, etc.) in DM-11321
+        self._submit_metrics = args.submit_metrics
+        self._squash_user = args.user
+        self._squash_password = args.password
+        self._squash_url = args.squash_url
+
+    def _save_measurements(self, fileName):
+        """Save a set of measurements for later use.
+
+        Parameters
+        ----------
+        fileName: `str`
+            The file to which the measurements will be saved.
+        """
+        self.job.write(fileName)
+
+    def _send_to_squash(self):
+        """Submit a set of measurements to the SQuaSH system.
+
+        Parameters
+        ----------
+        fileName: `str`
+            a file containing measurements in lsst.verify format
+        """
+        self.job.dispatch(api_user=self._squash_user, api_password=self._squash_password,
+                          api_url=self._squash_url)
+
+    @property
+    def job(self):
+        """The Job contained by this object.
+        """
+        return self._job
+
+    def __enter__(self):
+        """Allow the underlying Job to be used in with statements.
+        """
+        return self.job
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Package all metric measurements performed during this run.
+
+        The measurements shall be exported to `ap_verify.verify.json`, and the
+        metrics framework shall be shut down. If the context was exited
+        normally and the appropriate flag was passed to this object's
+        constructor, the measurements shall be sent to SQuaSH.
+        """
+        log = lsst.log.Log.getLogger('ap.verify.metrics.AutoJob.__exit__')
+
+        out_file = 'ap_verify.verify.json'
+        try:
+            self._save_measurements(out_file)
+            log.debug('Wrote measurements to %s', out_file)
+        except IOError:
+            if exc_type is None:
+                raise
+            else:
+                return False  # don't suppress `exc_value`
+
+        if exc_type is None and self._submit_metrics:
+            self._send_to_squash()
+            log.info('Submitted measurements to SQuaSH')
+        return False

--- a/python/lsst/ap/verify/pipeline.py
+++ b/python/lsst/ap/verify/pipeline.py
@@ -1,0 +1,79 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+from abc import ABCMeta, abstractmethod
+
+
+class Pipeline(object):
+    """A wrapper for an LSST pipeline.
+
+    Subclasses of this class represent a particular data processing framework.
+    If the `ap_verify` framework is ever extended or adapted to pipelines other
+    than `ap_pipe`, Pipeline objects may be used to decouple the choice of
+    pipeline from the rest of the framework (e.g., using a factory).
+
+    Subclasses must implement the `run` method, which executes the complete
+    pipeline.
+
+    Parameters
+    ----------
+    dataset: `dataset.Dataset`
+        The dataset on which the pipeline will be run.
+    working_dir: `str`
+        The repository in which temporary products will be created. Must be
+        compatible with `dataset`.
+
+    Attributes
+    ----------
+    dataset: `dataset.Dataset`
+        the dataset for this pipeline; to be used for ingestion and metadata
+    repo: `str`
+        the location of the repository in which the pipeline will work.
+        Subclasses may impose subrepositories or other structure.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, dataset, working_dir):
+        self.dataset = dataset
+        self.repo = working_dir
+
+    @abstractmethod
+    def run(self, metrics_job):
+        """Execute this pipeline.
+
+        An implementation must ingest raw data from `self.dataset` to
+        `self.repo`, then carry out all required processing. It may store
+        measurements and metadata in `metrics_job`, but must not export or
+        otherwise post-process those measurements.
+
+        This method is not called by Pipeline, so implementation decisions in
+        a subclass will not have unintended consequences.
+
+        Parameters
+        ----------
+        metrics_job: `verify.Job`
+            The Job object to which to add any metric measurements made.
+        """
+        raise NotImplementedError

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,108 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+import shlex
+import unittest
+
+import lsst.utils.tests
+import lsst.ap.verify.ap_verify as ap_verify
+
+
+class CommandLineTestSuite(lsst.utils.tests.TestCase):
+
+    def _parseString(self, command_line):
+        """Tokenize and parse a command line string.
+
+        Parameters
+        ----------
+        command_line: `str`
+            a string containing Unix-style command line arguments, but not the
+            name of the program
+        """
+        return ap_verify._VerifyApParser().parse_args(shlex.split(command_line))
+
+    def test_missing(self):
+        """Verify that a command line consisting missing required arguments is rejected.
+        """
+        args = '--dataset HiTS2015 --output tests/output/foo'
+        with self.assertRaises(SystemExit):
+            self._parseString(args)
+
+    def test_minimum(self):
+        """Verify that a command line consisting only of required arguments parses correctly.
+        """
+        args = '--dataset HiTS2015 --output tests/output/foo --dataIdString "visit=54123"'
+        parsed = self._parseString(args)
+        self.assertIn('dataset', dir(parsed))
+        self.assertIn('output', dir(parsed))
+        self.assertIn('dataId', dir(parsed))
+
+    def test_rerun(self):
+        """Verify that a command line with reruns is handled correctly.
+        """
+        args = '--dataset HiTS2015 --rerun me --dataIdString "visit=54123"'
+        parsed = self._parseString(args)
+        out = ap_verify._get_output_dir('non_lsst_repo/', parsed.output, parsed.rerun)
+        self.assertEqual(out, 'non_lsst_repo/rerun/me')
+
+    def test_rerun_input(self):
+        """Verify that a command line trying to redirect input is rejected.
+        """
+        args = '--dataset HiTS2015 --rerun from:to --dataIdString "visit=54123"'
+        with self.assertRaises(SystemExit):
+            self._parseString(args)
+
+    def test_two_outputs(self):
+        """Verify that a command line with both --output and --rerun is rejected.
+        """
+        args = '--dataset HiTS2015 --output tests/output/foo --rerun me --dataIdString "visit=54123"'
+        with self.assertRaises(SystemExit):
+            self._parseString(args)
+
+    def test_bad_dataset(self):
+        """Verify that a command line with an unregistered dataset is rejected.
+        """
+        args = '--dataset FooScope --output tests/output/foo --dataIdString "visit=54123"'
+        with self.assertRaises(SystemExit):
+            self._parseString(args)
+
+    def test_bad_key(self):
+        """Verify that a command line with unsupported arguments is rejected.
+        """
+        args = '--dataset HiTS2015 --output tests/output/foo --dataIdString "visit=54123" --clobber'
+        with self.assertRaises(SystemExit):
+            self._parseString(args)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,109 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+import os
+import shutil
+import unittest
+
+import lsst.utils.tests
+from lsst.ap.verify.dataset import Dataset
+
+
+class DatasetTestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self._testbed = Dataset('HiTS2015')
+
+    def test_init(self):
+        """Verify that if a Dataset object exists, the corresponding data are available.
+        """
+        # EUPS does not provide many guarantees about what setting up a package means
+        self.assertIsNotNone(os.getenv('AP_VERIFY_HITS2015_DIR'))
+
+    def test_datasets(self):
+        """Verify that a Dataset knows its supported datasets.
+        """
+        datasets = Dataset.get_supported_datasets()
+        self.assertIn('HiTS2015', datasets)  # assumed by other tests
+
+        # Initializing another Dataset has side effects, alas, but should not
+        # invalidate tests of whether HiTS2015 has been loaded
+        for dataset in datasets:
+            Dataset(dataset)
+
+    def test_directories(self):
+        """Verify that a Dataset reports the desired directory structure.
+        """
+        root = self._testbed.dataset_root
+        self.assertEqual(self._testbed.data_location, os.path.join(root, 'raw'))
+        self.assertEqual(self._testbed.calib_location, os.path.join(root, 'calib'))
+        self.assertEqual(self._testbed.template_location, os.path.join(root, 'templates'))
+
+    def test_output(self):
+        """Verify that a Dataset can create an output repository as desired.
+        """
+        test_dir = os.path.dirname(__file__)
+        output = os.path.join(test_dir, 'hitsOut')
+        self.assertFalse(os.path.exists(output), 'Output test invalid if directory exists.')
+
+        try:
+            self._testbed.make_output_repo(output)
+            self.assertTrue(os.path.exists(output), 'Output directory must exist.')
+            self.assertTrue(os.listdir(output), 'Output directory must not be empty.')
+            self.assertTrue(os.path.exists(os.path.join(output, '_mapper')),
+                            'Output directory must have a _mapper file.')
+        finally:
+            if os.path.exists(output):
+                shutil.rmtree(output)
+
+    def test_bad_output(self):
+        """Verify that a Dataset will not create an output directory if it is unsafe to do so.
+        """
+        test_dir = os.path.dirname(__file__)
+        output_dir = os.path.join(test_dir, 'badOut')
+
+        try:
+            os.makedirs(output_dir)
+            output = os.path.join(output_dir, 'foo.txt')
+            with open(output, 'w') as dummy:
+                dummy.write('This is a test!')
+
+            with self.assertRaises(IOError):
+                self._testbed.make_output_repo(output_dir)
+        finally:
+            if os.path.exists(output_dir):
+                shutil.rmtree(output_dir)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/ups/ap_verify.table
+++ b/ups/ap_verify.table
@@ -6,5 +6,7 @@ setupRequired(utils)
 setupRequired(pyyaml)
 setupRequired(verify)
 
+setupOptional(ap_verify_hits2015)
+
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
This is an initial implementation for `verify_ap`. It should be equivalent to the pseudocode on [DM-11118](https://jira.lsstcorp.org/browse/DM-11118), except that it has two afterburners and adds explicit support for `lsst.verify`.

The current code does not run because there are no working datasets, so the constructor of `Dataset` always raises. In addition, the stubs in `pipedriver` all raise `NotImplementedError`. However, `test_args` does run, and the main program's command-line parser is functional:

    $ python python/lsst/verify/ap/verify_ap.py -h
    usage: verify_ap.py [-h] --dataIdString DATAID [-j PROCESSES] [--silent]
                        --dataset {HiTS} (--output OUTPUT | --rerun OUTPUT)
                        [--version]

    Executes the LSST DM AP pipeline and analyzes its performance using metrics.

    optional arguments:
      -h, --help            show this help message and exit
      --dataIdString DATAID
                            An identifier for the data to process. Syntax and
                            meaning same as --id in Tasks.
      -j PROCESSES, --processes PROCESSES
                            Number of processes to use
      --silent              Do NOT submit metrics to SQuaSH (not yet implemented).
      --dataset {HiTS}      The source of data to pass through the pipeline.
      --output OUTPUT       The location of the repository to use for program
                            output.
      --rerun OUTPUT        The location of the repository to use for program
                            output, as DATASET/rerun/OUTPUT
      --version             show program's version number and exit
