### PR TITLE
DM-11650: Clean up file-based unit tests in ap_verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 *~
 .cache
+pytest_session.txt
 .sconf_temp
 .sconsign.dblite
 bin/*.py

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -39,6 +39,7 @@ CALIBINGESTED_DIR = 'calibingested'
 PROCESSED_DIR = 'processed'
 DIFFIM_DIR = 'diffim'
 
+
 class ApPipeParser(argparse.ArgumentParser):
     """An argument parser for data needed by ap_pipe activities.
 
@@ -53,7 +54,7 @@ class ApPipeParser(argparse.ArgumentParser):
                           help='An identifier for the data to process. '
                           'May not support all features of a Butler dataId; '
                           'see the ap_pipe documentation for details.')
-        self.add_argument("-j", "--processes", default=1, type=int, 
+        self.add_argument("-j", "--processes", default=1, type=int,
                           help="Number of processes to use. Not yet implemented.")
 
 
@@ -319,8 +320,8 @@ def run_ap_pipe(dataset, working_repo, parsed_cmd_line, metrics_job):
 
     metadata.combine(_difference(working_repo, dataId, processes, metrics_job))
     log.info('Image differencing complete')
-    #metadata.combine(_associate(working_repo, processes, metrics_job))
-    #log.info('Source association complete')
+    # metadata.combine(_associate(working_repo, processes, metrics_job))
+    # log.info('Source association complete')
 
     _post_process(working_repo)
     log.info('Pipeline complete')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -66,14 +66,13 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
         """Verify that a Dataset can create an output repository as desired.
         """
         test_dir = tempfile.mkdtemp(dir=os.path.dirname(__file__))
-        output = os.path.join(test_dir, 'hitsOut')
-        self.assertFalse(os.path.exists(output), 'Output test invalid if directory exists.')
+        output_dir = os.path.join(test_dir, 'hitsOut')
 
         try:
-            self._testbed.make_output_repo(output)
-            self.assertTrue(os.path.exists(output), 'Output directory must exist.')
-            self.assertTrue(os.listdir(output), 'Output directory must not be empty.')
-            self.assertTrue(os.path.exists(os.path.join(output, '_mapper')),
+            self._testbed.make_output_repo(output_dir)
+            self.assertTrue(os.path.exists(output_dir), 'Output directory must exist.')
+            self.assertTrue(os.listdir(output_dir), 'Output directory must not be empty.')
+            self.assertTrue(os.path.exists(os.path.join(output_dir, '_mapper')),
                             'Output directory must have a _mapper file.')
         finally:
             if os.path.exists(test_dir):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import shutil
+import tempfile
 import unittest
 
 import lsst.utils.tests
@@ -64,7 +65,7 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
     def test_output(self):
         """Verify that a Dataset can create an output repository as desired.
         """
-        test_dir = os.path.dirname(__file__)
+        test_dir = tempfile.mkdtemp(dir=os.path.dirname(__file__))
         output = os.path.join(test_dir, 'hitsOut')
         self.assertFalse(os.path.exists(output), 'Output test invalid if directory exists.')
 
@@ -75,13 +76,13 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
             self.assertTrue(os.path.exists(os.path.join(output, '_mapper')),
                             'Output directory must have a _mapper file.')
         finally:
-            if os.path.exists(output):
-                shutil.rmtree(output)
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
 
     def test_bad_output(self):
         """Verify that a Dataset will not create an output directory if it is unsafe to do so.
         """
-        test_dir = os.path.dirname(__file__)
+        test_dir = tempfile.mkdtemp(dir=os.path.dirname(__file__))
         output_dir = os.path.join(test_dir, 'badOut')
 
         try:
@@ -93,8 +94,8 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
             with self.assertRaises(IOError):
                 self._testbed.make_output_repo(output_dir)
         finally:
-            if os.path.exists(output_dir):
-                shutil.rmtree(output_dir)
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR uses `mkdtemp` to manage tests of `Dataset.make_output_repo`. Because the tested functionality includes directory creation, the modified tests create a second directory inside the temporary.