### PR TITLE
DM-12853: Review design questions in ap_verify

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -84,7 +84,7 @@ Required arguments are :option:`--dataset`, :option:`--dataIdString`, and exactl
 
    See :doc:`command-line-task-data-repo-howto` for background.
 
-   .. TODO: I think the --rerun argument may have been a mistake -- it's almost entirely not quite unlike its command line task equivalent  (DM-12853)
+   .. TODO: Rework or remove --rerun (DM-13492)
 
 .. option:: --rerun <output>
 

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -22,8 +22,6 @@ These three arguments (or replacing ``--output`` with ``--rerun``) are mandatory
 Status code
 ===========
 
-.. TODO: should we require that ap_verify and ap_pipe follow the CmdLineTask convention? (DM-12853)
-
 ``ap_verify`` returns a status code of ``0`` if the pipeline ran to completion.
 If the pipeline fails, the status code will be an interpreter-dependent nonzero value.
 

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -15,7 +15,7 @@ The basic call signature of ``ap_verify`` is:
 
 .. code-block:: sh
 
-   python ap_verify.py --dataset DATASET --output OUTPUTREPO --dataIdString DATAID
+   python ap_verify.py --dataset DATASET --output OUTPUTREPO --id DATAID
 
 These three arguments (or replacing ``--output`` with ``--rerun``) are mandatory, all others are optional.
 
@@ -30,16 +30,16 @@ If the pipeline fails, the status code will be an interpreter-dependent nonzero 
 Named arguments
 ===============
 
-Required arguments are :option:`--dataset`, :option:`--dataIdString`, and exactly one of :option:`--output` or :option:`--rerun`.
+Required arguments are :option:`--dataset`, :option:`--id`, and exactly one of :option:`--output` or :option:`--rerun`.
 
-.. option:: --dataIdString <dataId>
+.. option:: --id <dataId>
 
    **Butler data ID.**
 
    The input data ID is required for all ``ap_verify`` runs except when using :option:`--help` or :option:`--version`.
 
    Specify data ID to process using data ID syntax.
-   For example, ``--dataIdString "visit=12345 ccd=1 filter=g"``.
+   For example, ``--id "visit=12345 ccd=1 filter=g"``.
    
    Currently this argument is heavily restricted compared to its :ref:`command line task counterpart<command-line-task-dataid-howto>`.
    In particular, the dataId must specify exactly one visit and exactly one CCD, and may not be left blank to mean "all data".

--- a/doc/lsst.ap.verify/datasets-creation.rst
+++ b/doc/lsst.ap.verify/datasets-creation.rst
@@ -52,5 +52,5 @@ The observatory package must be named in two files:
 Registering a Dataset Name
 --------------------------
 
-In order to be supported by ``ap_verify``, datasets must be registered in the package's :ref:`configuration file<ap-verify-configuration-dataset>`.
+In order to be supported by ``ap_verify``, datasets must be registered in the package's :ref:`configuration file<ap-verify-configuration-dataset>` and registered as an *optional* EUPS dependency of ``ap_verify``.
 The line for the new dataset should be committed to the ``ap_verify`` Git repository.

--- a/doc/lsst.ap.verify/datasets-install.rst
+++ b/doc/lsst.ap.verify/datasets-install.rst
@@ -25,8 +25,6 @@ Installation Procedure
 Use Git LFS to clone the desired dataset's GitHub repository.
 To get the URL, see the :ref:`package documentation<ap-verify-datasets-index>` for the dataset in question.
 
-.. TODO: should we have a proper versioning system for datasets? (DM-12853)
-
 Once the dataset has been installed, use :command:`eups declare` to register the downloaded directory.
 The product name given to EUPS must match the repository name; the version can be anything.
 It is also possible to register the dataset using :command:`setup`, but this is recommended only for temporary tests.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -27,11 +27,9 @@ How to Run ap_verify in a New Workspace
 
 Using the :ref:`HiTS 2015 <ap_verify_hits2015-package>` dataset as an example, one can run ``ap_verify`` as follows:
 
-.. TODO: why dataIdString instead of id or dataId? (DM-12853)
-
 .. prompt:: bash
 
-   python ap_verify/bin/ap_verify.py --dataset HiTS2015 --output workspace/hits/ --dataIdString "visit=54123 ccd=25 filter=g" --silent
+   python ap_verify/bin/ap_verify.py --dataset HiTS2015 --output workspace/hits/ --id "visit=54123 ccd=25 filter=g" --silent
 
 Here:
 
@@ -64,7 +62,7 @@ It is also possible to place a workspace in a subdirectory of a dataset director
 
 .. prompt:: bash
 
-   python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --rerun run1 --dataIdString "visit=54123 ccd=25 filter=g" --silent
+   python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --rerun run1 --id "visit=54123 ccd=25 filter=g" --silent
 
 The :command:`--rerun run1` argument will create a workspace in :file:`<hits-data>/rerun/run1/`.
 Since datasets are :ref:`not, in general, repositories<ap-verify-datasets-butler>`, the :option:`--rerun <ap_verify.py --rerun>` parameter only superficially resembles the analogous argument for command-line tasks.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -16,10 +16,9 @@ Datasets as Input Arguments
 
 Since ``ap_verify`` begins with an uningested :ref:`dataset<ap-verify-datasets>`, the input argument is a dataset name rather than a repository.
 
-.. TODO: is the abstraction of having a separate `dataset` name useful, or does it just impose more work on the user (who needs the repo name anyway to install the dataset)? (DM-12853)
-
 Datasets are identified by a name that gets mapped to an :ref:`eups-registered directory <ap-verify-datasets-install>` containing the data.
 The mapping is :ref:`configurable<ap-verify-configuration-dataset>`.
+The dataset names are a placeholder for a future data repository versioning system, and may be replaced in a later version of ``ap_verify``.
 
 .. _ap-verify-run-output:
 

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -24,9 +24,9 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import shutil
+from future.utils import raise_from
 
-from eups import Eups
-
+import lsst.pex.exceptions as pexExcept
 from lsst.utils import getPackageDir
 
 from .config import Config
@@ -90,20 +90,28 @@ class Dataset(object):
         except KeyError:
             raise ValueError('Unsupported dataset: ' + datasetId)
 
-        self._dataRootDir = getPackageDir(datasetPackage)
-        self._validatePackage()
+        try:
+            self._dataRootDir = getPackageDir(datasetPackage)
+        except pexExcept.NotFoundError as e:
+            raise_from(
+                RuntimeError('Dataset %s requires the %s package, which has not been set up.'
+                             % (datasetId, datasetPackage)),
+                e)
+        else:
+            self._validatePackage()
 
         self._initPackage(datasetPackage)
 
     def _initPackage(self, name):
-        """Load the package backing this dataset.
+        """Prepare the package backing this dataset.
 
         Parameters
         ----------
         name : `str`
            The EUPS package identifier for the desired package.
         """
-        Eups().setup(name)
+        # No initialization required at present
+        pass
 
     @staticmethod
     def getSupportedDatasets():

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -54,7 +54,7 @@ class ApPipeParser(argparse.ArgumentParser):
     def __init__(self):
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
-        self.add_argument('--dataIdString', dest='dataId', required=True,
+        self.add_argument('--id', dest='dataId', required=True,
                           help='An identifier for the data to process. '
                           'May not support all features of a Butler dataId; '
                           'see the ap_pipe documentation for details.')

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -52,7 +52,7 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
     def testMinimum(self):
         """Verify that a command line consisting only of required arguments parses correctly.
         """
-        args = '--dataset HiTS2015 --output tests/output/foo --dataIdString "visit=54123"'
+        args = '--dataset HiTS2015 --output tests/output/foo --id "visit=54123"'
         parsed = self._parseString(args)
         self.assertIn('dataset', dir(parsed))
         self.assertIn('output', dir(parsed))
@@ -61,7 +61,7 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
     def testRerun(self):
         """Verify that a command line with reruns is handled correctly.
         """
-        args = '--dataset HiTS2015 --rerun me --dataIdString "visit=54123"'
+        args = '--dataset HiTS2015 --rerun me --id "visit=54123"'
         parsed = self._parseString(args)
         out = ap_verify._getOutputDir('non_lsst_repo/', parsed.output, parsed.rerun)
         self.assertEqual(out, 'non_lsst_repo/rerun/me')
@@ -69,28 +69,28 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
     def testRerunInput(self):
         """Verify that a command line trying to redirect input is rejected.
         """
-        args = '--dataset HiTS2015 --rerun from:to --dataIdString "visit=54123"'
+        args = '--dataset HiTS2015 --rerun from:to --id "visit=54123"'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 
     def testTwoOutputs(self):
         """Verify that a command line with both --output and --rerun is rejected.
         """
-        args = '--dataset HiTS2015 --output tests/output/foo --rerun me --dataIdString "visit=54123"'
+        args = '--dataset HiTS2015 --output tests/output/foo --rerun me --id "visit=54123"'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 
     def testBadDataset(self):
         """Verify that a command line with an unregistered dataset is rejected.
         """
-        args = '--dataset FooScope --output tests/output/foo --dataIdString "visit=54123"'
+        args = '--dataset FooScope --output tests/output/foo --id "visit=54123"'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 
     def testBadKey(self):
         """Verify that a command line with unsupported arguments is rejected.
         """
-        args = '--dataset HiTS2015 --output tests/output/foo --dataIdString "visit=54123" --clobber'
+        args = '--dataset HiTS2015 --output tests/output/foo --id "visit=54123" --clobber'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -45,13 +45,6 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
     def setUp(self):
         self._testbed = Dataset(DatasetTestSuite.datasetKey)
 
-    # TODO: remove after Datasets no longer perform Eups setup (DM-12853)
-    def testInit(self):
-        """Verify that if a Dataset object exists, the corresponding data are available.
-        """
-        # EUPS does not provide many guarantees about what setting up a package means
-        self.assertIsNotNone(os.getenv('AP_VERIFY_HITS2015_DIR'))
-
     def testDatasets(self):
         """Verify that a Dataset knows its supported datasets.
         """


### PR DESCRIPTION
This PR updates the `ap_verify` documentation to comply with the decisions made on [DM-12853](https://jira.lsstcorp.org/browse/DM-12853). Two changes require concurrent updates to source code: renaming `--dataIdString` to `--id` and removing self-setup capability from datasets.

The built documentation is available in [zip format](https://github.com/lsst-dm/ap_verify/files/1696892/docs.zip).