### PR TITLE
DM-13451: Make ap_verify responsible for ingestion

### DIFF
--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -36,6 +36,7 @@ import re
 
 import lsst.log
 from .dataset import Dataset
+from .ingestion import ingestDataset
 from .metrics import MetricsParser, checkSquashReady, AutoJob
 from .pipeline_driver import ApPipeParser, runApPipe
 from .measurements import measureFromMetadata, \
@@ -186,8 +187,7 @@ def runApVerify(cmdLine=None):
     testData = Dataset(args.dataset)
     log.info('Dataset %s set up.', args.dataset)
     output = _getOutputDir(testData.datasetRoot, args.output, args.rerun)
-    testData.makeOutputRepo(output)
-    log.info('Output repo at %s created.', output)
+    ingestDataset(testData, output)
 
     with AutoJob(args) as job:
         log.info('Running pipeline...')

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -191,5 +191,5 @@ def runApVerify(cmdLine=None):
 
     with AutoJob(args) as job:
         log.info('Running pipeline...')
-        metadata = runApPipe(job, testData, output, args)
+        metadata = runApPipe(job, output, args)
         _measureFinalProperties(job, metadata, output, args)

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -68,7 +68,7 @@ class Dataset(object):
     Any object of this class is guaranteed to represent a ready-for-use
     dataset, barring concurrent changes to the file system or EUPS operations.
     Constructing a Dataset does not create a compatible output repository(ies),
-    which can be done by calling `makeOutputRepo`.
+    which can be done by calling `makeCompatibleRepo`.
 
     Parameters
     ----------
@@ -261,16 +261,16 @@ class Dataset(object):
         if not os.path.exists(os.path.join(self._stubInputRepo, '_mapper')):
             raise RuntimeError('Stub repo at ' + self._stubInputRepo + 'is missing mapper file')
 
-    def makeOutputRepo(self, outputDir):
-        """Set up a directory as an output repository compatible with this dataset.
+    def makeCompatibleRepo(self, repoDir):
+        """Set up a directory as a repository compatible with this dataset.
 
         If the directory already exists, any files required by the dataset will
         be added if absent; otherwise the directory will remain unchanged.
 
         Parameters
         ----------
-        outputDir : `str`
+        repoDir : `str`
             The directory where the output repository will be created.
         """
         # shutil.copytree has wrong behavior for existing destinations, do it by hand
-        _nicecopy(self._stubInputRepo, outputDir)
+        _nicecopy(self._stubInputRepo, repoDir)

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -74,7 +74,7 @@ def ingestDataset(dataset, repository):
 
 
 def _ingestRaws(dataset, workingRepo):
-    """Ingest the raw data for use by LSST.
+    """Ingest the science data for use by LSST.
 
     The original data directory shall not be modified.
 
@@ -95,7 +95,7 @@ def _ingestRaws(dataset, workingRepo):
 
 
 def _ingestCalibs(dataset, workingRepo):
-    """Ingest the raw calibrations for use by LSST.
+    """Ingest the calibration files for use by LSST.
 
     The original calibration directory shall not be modified.
 

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -60,7 +60,7 @@ def ingestDataset(dataset, repository):
     """
     # TODO: generalize to support arbitrary URIs (DM-11482)
     log = lsst.log.Log.getLogger('ap.verify.ingestion.ingestDataset')
-    dataset.makeOutputRepo(repository)
+    dataset.makeCompatibleRepo(repository)
     log.info('Output repo at %s created.', repository)
     metadata = dafBase.PropertySet()
     temp = _ingestRaws(dataset, repository)

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -1,0 +1,115 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Data ingestion for ap_verify.
+
+This module handles ingestion of a dataset into an appropriate repository, so
+that pipeline code need not be aware of the dataset framework.
+
+At present, the code is specific to DECam; it will be generalized to other
+instruments in the future.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["ingestDataset"]
+
+import lsst.log
+import lsst.daf.base as dafBase
+import lsst.ap.pipe as apPipe
+
+
+def ingestDataset(dataset, repository):
+    """Ingest the contents of a dataset into a Butler repository.
+
+    The original data directory shall not be modified.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset to be ingested.
+    repository : `str`
+        The file location of a repository to which the data will be ingested.
+        Shall be created if it does not exist. If `repository` does exist, it
+        must be compatible with `dataset` (in particular, it must support the
+        relevant ``obs`` package).
+
+    Returns
+    -------
+    metadata : `lsst.daf.base.PropertySet`
+        The full metadata from any Tasks called by this function.
+    """
+    # TODO: generalize to support arbitrary URIs (DM-11482)
+    log = lsst.log.Log.getLogger('ap.verify.ingestion.ingestDataset')
+    dataset.makeOutputRepo(repository)
+    log.info('Output repo at %s created.', repository)
+    metadata = dafBase.PropertySet()
+    temp = _ingestRaws(dataset, repository)
+    if temp is not None:
+        metadata.combine(temp)
+    temp = _ingestCalibs(dataset, repository)
+    if temp is not None:
+        metadata.combine(temp)
+    log.info('Data ingested')
+    return metadata
+
+
+def _ingestRaws(dataset, workingRepo):
+    """Ingest the raw data for use by LSST.
+
+    The original data directory shall not be modified.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset on which the pipeline will be run.
+    workingRepo : `str`
+        The repository in which temporary products will be created. Must be
+        compatible with `dataset`.
+
+    Returns
+    -------
+    metadata : `lsst.daf.base.PropertySet`
+        The full metadata from any Tasks called by this method, or `None`.
+    """
+    return apPipe.doIngest(workingRepo, dataset.rawLocation, dataset.refcatsLocation)
+
+
+def _ingestCalibs(dataset, workingRepo):
+    """Ingest the raw calibrations for use by LSST.
+
+    The original calibration directory shall not be modified.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset on which the pipeline will be run.
+    workingRepo : `str`
+        The repository in which temporary products will be created. Must be
+        compatible with `dataset`.
+
+    Returns
+    -------
+    metadata : `lsst.daf.base.PropertySet`
+        The full metadata from any Tasks called by this method, or `None`.
+    """
+    return apPipe.doIngestCalibs(workingRepo, dataset.calibLocation, dataset.defectLocation)

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -33,9 +33,26 @@ from __future__ import absolute_import, division, print_function
 
 __all__ = ["ingestDataset"]
 
+import os
+import tarfile
+from glob import glob
+import sqlite3
+
 import lsst.log
+from lsst.obs.decam import ingest
+from lsst.obs.decam import ingestCalibs
+from lsst.obs.decam.ingest import DecamParseTask
+from lsst.pipe.tasks.ingest import IngestConfig
+from lsst.pipe.tasks.ingestCalibs import IngestCalibsConfig, IngestCalibsTask
+from lsst.pipe.tasks.ingestCalibs import IngestCalibsArgumentParser
 import lsst.daf.base as dafBase
-import lsst.ap.pipe as apPipe
+
+# Names of directories to be created in specified repository
+INGESTED_DIR = 'ingested'
+CALIBINGESTED_DIR = 'calibingested'
+
+# Name of defects tarball residing in dataset's defects directory
+DEFECT_TARBALL = 'defects_2014-12-05.tar.gz'
 
 
 def ingestDataset(dataset, repository):
@@ -91,7 +108,7 @@ def _ingestRaws(dataset, workingRepo):
     metadata : `lsst.daf.base.PropertySet`
         The full metadata from any Tasks called by this method, or `None`.
     """
-    return apPipe.doIngest(workingRepo, dataset.rawLocation, dataset.refcatsLocation)
+    return doIngest(workingRepo, dataset.rawLocation, dataset.refcatsLocation)
 
 
 def _ingestCalibs(dataset, workingRepo):
@@ -112,4 +129,405 @@ def _ingestCalibs(dataset, workingRepo):
     metadata : `lsst.daf.base.PropertySet`
         The full metadata from any Tasks called by this method, or `None`.
     """
-    return apPipe.doIngestCalibs(workingRepo, dataset.calibLocation, dataset.defectLocation)
+    return doIngestCalibs(workingRepo, dataset.calibLocation, dataset.defectLocation)
+
+
+def doIngest(base_repo, raw_dir, refcat_dir):
+    '''
+    Ingest raw DECam images and reference catalogs into a repository
+
+    Parameters
+    ----------
+    base_repo: `str`
+        The output repository location on disk.
+    raw_dir: `str`
+        A directory containing raw image files.
+    refcats: `str`
+        A directory containing two .tar.gz files with LSST-formatted astrometric
+        and photometric reference catalog information. The filenames are set below.
+
+    Returns
+    -------
+    ingest_metadata: `PropertySet` or None
+        Metadata from the IngestTask for use by ap_verify
+
+    Notes
+    -----
+    This function ingests *all* the images, not just the ones for the
+    specified visits and/or filters. We may want to revisit this in the future.
+    '''
+    raw_repo = get_output_repo(base_repo, INGESTED_DIR)
+    datafiles = get_datafiles(raw_dir)
+    return _doIngest(raw_repo, refcat_dir, datafiles)
+
+
+def _doIngest(repo, refcats, datafiles):
+    '''
+    Ingest raw DECam images into a repository with a corresponding registry
+
+    Parameters
+    ----------
+    repo: `str`
+        The output repository location on disk where ingested raw images live.
+    refcats: `str`
+        A directory containing two .tar.gz files with LSST-formatted astrometric
+        and photometric reference catalog information. The filenames are set below.
+    datafiles: `list`
+        A list of the filenames of each raw image file.
+
+    BASH EQUIVALENT:
+    $ ingestImagesDecam.py repo --filetype raw --mode link datafiles
+    ** If run from bash, refcats must also be manually copied or symlinked to repo
+
+    Returns
+    -------
+    ingest_metadata: `PropertySet` or None
+        Metadata from the IngestTask for use by ap_verify
+
+    RESULT:
+    repo populated with *links* to datafiles, organized by date
+    sqlite3 database registry of ingested images also created in repo
+
+    NOTE:
+    This functions ingests *all* the images, not just the ones for the
+    specified visits and/or filters. We may want to revisit this in the future.
+    '''
+    # Names of tarballs containing astrometric and photometric reference catalog files
+    ASTROM_REFCAT_TAR = 'gaia_HiTS_2015.tar.gz'
+    PHOTOM_REFCAT_TAR = 'ps1_HiTS_2015.tar.gz'
+
+    # Names of reference catalog directories processCcd expects to find in repo
+    ASTROM_REFCAT_DIR = 'ref_cats/gaia'
+    PHOTOM_REFCAT_DIR = 'ref_cats/pan-starrs'
+
+    log = lsst.log.Log.getLogger('ap.pipe._doIngest')
+    if os.path.exists(os.path.join(repo, 'registry.sqlite3')):
+        log.warn('Raw images were previously ingested, skipping...')
+        return None
+    # TODO: make this a new-style repository (DM-12662)
+    if not os.path.isdir(repo):
+        os.mkdir(repo)
+    # make a text file that handles the mapper, per the obs_decam github README
+    with open(os.path.join(repo, '_mapper'), 'w') as f:
+        print('lsst.obs.decam.DecamMapper', file=f)
+    log.info('Ingesting raw images...')
+    # save arguments you'd put on the command line after 'ingestImagesDecam.py'
+    # (extend the list with all the filenames as the last set of arguments)
+    args = [repo, '--filetype', 'raw', '--mode', 'link']
+    args.extend(datafiles)
+    # set up the decam ingest task so it can take arguments
+    # ('name' says which file in obs_decam/config to use)
+    argumentParser = ingest.DecamIngestArgumentParser(name='ingest')
+    # create an instance of ingest configuration
+    # the retarget command is from line 2 of obs_decam/config/ingest.py
+    config = IngestConfig()
+    config.parse.retarget(DecamParseTask)
+    # create an *instance* of the decam ingest task
+    ingestTask = ingest.DecamIngestTask(config=config)
+    # feed everything to the argument parser
+    parsedCmd = argumentParser.parse_args(config=config, args=args)
+    # finally, run the ingestTask
+    ingestTask.run(parsedCmd)
+    # Copy refcats files to repo (needed for doProcessCcd)
+    astrom_tarball = os.path.join(refcats, ASTROM_REFCAT_TAR)
+    photom_tarball = os.path.join(refcats, PHOTOM_REFCAT_TAR)
+    tarfile.open(astrom_tarball, 'r').extractall(os.path.join(repo, ASTROM_REFCAT_DIR))
+    tarfile.open(photom_tarball, 'r').extractall(os.path.join(repo, PHOTOM_REFCAT_DIR))
+    log.info('Images are now ingested in {0}'.format(repo))
+    ingest_metadata = ingestTask.getFullMetadata()
+    return ingest_metadata
+
+
+def flatBiasIngest(repo, calib_repo, calib_datafiles):
+    '''
+    Ingest DECam flats and biases (called by _doIngestCalibs)
+
+    Parameters
+    ----------
+    repo: `str`
+        The output repository location on disk where ingested raw images live.
+    calib_repo: `str`
+        The output repository location on disk where ingested calibration images live.
+    calib_datafiles: `list`
+        A list of the filenames of each flat and bias image file.
+
+    Returns
+    -------
+    flatBias_metadata: `PropertySet` or None
+        Metadata from the IngestCalibTask (flats and biases) for use by ap_verify
+
+    BASH EQUIVALENT:
+    $ ingestCalibs.py repo --calib calib_repo --mode=link --validity 999 calib_datafiles
+    '''
+    log = lsst.log.Log.getLogger('ap.pipe.flatBiasIngest')
+    log.info('Ingesting flats and biases...')
+    args = [repo, '--calib', calib_repo, '--mode', 'link', '--validity', '999']
+    args.extend(calib_datafiles)
+    argumentParser = IngestCalibsArgumentParser(name='ingestCalibs')
+    config = IngestCalibsConfig()
+    config.parse.retarget(ingestCalibs.DecamCalibsParseTask)
+    calibIngestTask = IngestCalibsTask(config=config, name='ingestCalibs')
+    parsedCmd = argumentParser.parse_args(config=config, args=args)
+    try:
+        calibIngestTask.run(parsedCmd)
+    except sqlite3.IntegrityError as detail:
+        log.error('sqlite3.IntegrityError: ', detail)
+        log.error('(sqlite3 doesn\'t think all the calibration files are unique)')
+        raise
+    else:
+        log.info('Success!')
+        log.info('Calibrations corresponding to {0} are now ingested in {1}'.format(repo, calib_repo))
+        flatBias_metadata = calibIngestTask.getFullMetadata()
+    return flatBias_metadata
+
+
+def defectIngest(repo, calib_repo, defectfiles):
+    '''
+    Ingest DECam defect images (called by _doIngestCalibs)
+
+    Parameters
+    ----------
+    repo: `str`
+        The output repository location on disk where ingested raw images live.
+    calib_repo: `str`
+        The output repository location on disk where ingested calibration images live.
+    defectfiles: `list`
+        A list of the filenames of each defect image file.
+        The first element in this list must be the name of a .tar.gz file
+        which contains all the compressed defect images.
+
+    Returns
+    -------
+    defect_metadata: `PropertySet` or None
+        Metadata from the IngestCalibTask (defects) for use by ap_verify
+
+    BASH EQUIVALENT:
+    $ cd calib_repo
+    $ ingestCalibs.py ../../repo --calib . --mode=skip --calibType defect --validity 999 defectfiles
+    $ cd ..
+
+    This function assumes very particular things about defect ingestion:
+    - They must live in a .tar.gz file in the same location on disk as the other calibs
+    - They will be ingested using ingestCalibs.py run from the calib_repo directory
+    - They will be manually uncompressed and saved in calib_repo/defects/<tarballname>/.
+    - They will be added to the calib registry, but not linked like the flats and biases
+    '''
+    # TODO: clean up implementation after DM-5467 resolved
+    log = lsst.log.Log.getLogger('ap.pipe.defectIngest')
+    absRepo = os.path.abspath(repo)
+    defect_tarball = os.path.abspath(defectfiles[0] + '.tar.gz')
+    startDir = os.path.abspath(os.getcwd())
+    # CameraMapper does not accept absolute paths
+    os.chdir(calib_repo)
+    try:
+        os.mkdir('defects')
+    except OSError:
+        # most likely the defects directory already exists
+        if os.path.isdir('defects'):
+            log.warn('Defects were previously ingested, skipping...')
+            defect_metadata = None
+        else:
+            log.error('Defect ingestion failed because \'defects\' dir could not be created')
+            raise
+    else:
+        log.info('Ingesting defects...')
+        defectargs = [absRepo, '--calib', '.', '--calibType', 'defect',
+                      '--mode', 'skip', '--validity', '999']
+        tarfile.open(defect_tarball, 'r').extractall('defects')
+        defectfiles = glob(os.path.join('defects', os.path.basename(defectfiles[0]), '*.fits'))
+        defectargs.extend(defectfiles)
+        defectArgumentParser = IngestCalibsArgumentParser(name='ingestCalibs')
+        defectConfig = IngestCalibsConfig()
+        defectConfig.parse.retarget(ingestCalibs.DecamCalibsParseTask)
+        DefectIngestTask = IngestCalibsTask(config=defectConfig, name='ingestCalibs')
+        defectParsedCmd = defectArgumentParser.parse_args(config=defectConfig, args=defectargs)
+        DefectIngestTask.run(defectParsedCmd)
+        defect_metadata = DefectIngestTask.getFullMetadata()
+    finally:
+        os.chdir(startDir)
+    return defect_metadata
+
+
+def doIngestCalibs(base_repo, calib_dir, defect_dir):
+    '''
+    Ingest DECam MasterCal biases, flats, and defects into the working
+    repository.
+
+    Parameters
+    ----------
+    base_repo: `str`
+        The output repository location on disk.
+    calib_dir: `str`
+        The input directory containing the flat and bias image files.
+    defect_dir: `str`
+        The input directory containing the defect image files.
+
+    Returns
+    -------
+    calibingest_metadata: `PropertySet` or None
+        Metadata from the IngestCalibTask (flats and biases) and from the
+        IngestCalibTask (defects) for use by ap_verify
+
+    Notes
+    -----
+    calib ingestion ingests *all* the calibs, not just the ones needed
+    for certain visits. We may want to ...revisit... this in the future.
+    '''
+    repo = get_output_repo(base_repo, INGESTED_DIR)
+    calib_repo = get_output_repo(base_repo, CALIBINGESTED_DIR)
+    calib_datafiles = get_calib_datafiles(calib_dir)
+    defectfiles = get_defectfiles(defect_dir)
+    return _doIngestCalibs(repo, calib_repo, calib_datafiles, defectfiles)
+
+
+def _doIngestCalibs(repo, calib_repo, calib_datafiles, defectfiles):
+    '''
+    Ingest DECam MasterCal biases and flats into a calibration repository with a corresponding registry.
+    Also ingest DECam defects into the calib registry.
+
+    Parameters
+    ----------
+    repo: `str`
+        The output repository location on disk where ingested raw images live.
+    calib_repo: `str`
+        The output repository location on disk where ingested calibration images live.
+    calib_datafiles: `list`
+        A list of the filenames of each flat and bias image file.
+    defectfiles: `list`
+            A list of the filenames of each defect image file.
+            The first element in this list must be the name of a .tar.gz file
+            which contains all the compressed defect images.
+
+    Returns
+    -------
+    calibingest_metadata: `PropertySet` or None
+        Metadata from the IngestCalibTask (flats and biases) and from the
+        IngestCalibTask (defects) for use by ap_verify
+
+    RESULT:
+    calib_repo populated with *links* to calib_datafiles,
+    organized by date (bias and flat images only)
+    sqlite3 database registry of ingested calibration products (bias, flat,
+    and defect images) created in calib_repo
+
+    NOTE:
+    calib ingestion ingests *all* the calibs, not just the ones needed
+    for certain visits. We may want to ...revisit... this in the future.
+    '''
+    log = lsst.log.Log.getLogger('ap.pipe._doIngestCalibs')
+    if not os.path.isdir(calib_repo):
+        os.mkdir(calib_repo)
+        flatBias_metadata = flatBiasIngest(repo, calib_repo, calib_datafiles)
+        defect_metadata = defectIngest(repo, calib_repo, defectfiles)
+    elif os.path.exists(os.path.join(calib_repo, 'cpBIAS')):
+        log.warn('Flats and biases were previously ingested, skipping...')
+        flatBias_metadata = None
+        defect_metadata = defectIngest(repo, calib_repo, defectfiles)
+    else:
+        flatBias_metadata = flatBiasIngest(repo, calib_repo, calib_datafiles)
+        defect_metadata = defectIngest(repo, calib_repo, defectfiles)
+    # Handle the case where one or both of the calib metadatas may be None
+    if flatBias_metadata is not None:
+        calibingest_metadata = flatBias_metadata
+        if defect_metadata is not None:
+            calibingest_metadata.combine(defect_metadata)
+    else:
+        calibingest_metadata = defect_metadata
+    return calibingest_metadata
+
+
+def get_datafiles(raw_location):
+    '''
+    Retrieve a list of the raw DECam images for use during ingestion.
+
+    Parameters
+    ----------
+    raw_location: `str`
+        The path on disk to where the raw files live.
+
+    Returns
+    -------
+    datafiles: `list`
+        A list of the filenames of each raw image file.
+    '''
+    types = ('*.fits', '*.fz')
+    datafiles = []
+    for files in types:
+        datafiles.extend(glob(os.path.join(raw_location, files)))
+    return datafiles
+
+
+def get_calib_datafiles(calib_location):
+    '''
+    Retrieve a list of the DECam MasterCal flat and bias files for use during ingestion.
+
+    Parameters
+    ----------
+    calib_location: `str`
+        The path on disk to where the calibration files live.
+
+    Returns
+    -------
+    calib_datafiles: `list`
+        A list of the filenames of each flat and bias image file.
+    '''
+    types = ('*.fits', '*.fz')
+    all_calib_datafiles = []
+    for files in types:
+        all_calib_datafiles.extend(glob(os.path.join(calib_location, files)))
+    # Ignore wtmaps and illumcors
+    # These data products may be useful in the future, but are not yet supported by the Stack
+    # and will confuse the ingester
+    calib_datafiles = []
+    files_to_ignore = ['fcw', 'zcw', 'ici']
+    for file in all_calib_datafiles:
+        if all(string not in file for string in files_to_ignore):
+            calib_datafiles.append(file)
+    return calib_datafiles
+
+
+def get_defectfiles(defect_location, defect_tarball=DEFECT_TARBALL):
+    '''
+    Retrieve a list of the DECam defect files for use during ingestion.
+
+    Parameters
+    ----------
+    defect_location: `str`
+        The path on disk to where the defect tarball lives.
+    defect_tarball: `str`
+        The filename of the tarball containing the defect files.
+
+    Returns
+    -------
+    defectfiles: `list`
+        A list of the filenames of each defect image file.
+        The first element in this list will be the name of a .tar.gz file
+        which contains all the compressed defect images.
+    '''
+    # Retrieve defect filenames from tarball
+    defect_tarfile_path = os.path.join(defect_location, defect_tarball)
+    defectfiles = tarfile.open(defect_tarfile_path).getnames()
+    defectfiles = [os.path.join(defect_location, file) for file in defectfiles]
+    return defectfiles
+
+
+def get_output_repo(output_root, output_dir):
+    '''
+    Return location on disk for one output repository used by ap_pipe.
+
+    Parameters
+    ----------
+    output_root: `str`
+        The top-level directory where the output will live.
+    output_dir: `str`
+        Name of the subdirectory to be created in output_root.
+
+    Returns
+    -------
+    output_path: `str`
+        Repository (directory on disk) where desired output product will live.
+    '''
+    if not os.path.isdir(output_root):
+        os.mkdir(output_root)
+    output_path = os.path.join(output_root, output_dir)
+    return output_path

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -46,6 +46,7 @@ from lsst.pipe.tasks.ingest import IngestConfig
 from lsst.pipe.tasks.ingestCalibs import IngestCalibsConfig, IngestCalibsTask
 from lsst.pipe.tasks.ingestCalibs import IngestCalibsArgumentParser
 import lsst.daf.base as dafBase
+from lsst.ap.pipe import doIngestTemplates
 
 # Names of directories to be created in specified repository
 INGESTED_DIR = 'ingested'
@@ -87,6 +88,9 @@ def ingestDataset(dataset, repository):
     if temp is not None:
         metadata.combine(temp)
     log.info('Data ingested')
+    temp = _ingestTemplates(dataset, repository)
+    if temp is not None:
+        metadata.combine(temp)
     return metadata
 
 
@@ -130,6 +134,29 @@ def _ingestCalibs(dataset, workingRepo):
         The full metadata from any Tasks called by this method, or `None`.
     """
     return doIngestCalibs(workingRepo, dataset.calibLocation, dataset.defectLocation)
+
+
+def _ingestTemplates(dataset, workingRepo):
+    """Ingest the templates for use by LSST.
+
+    The original template repository shall not be modified.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The dataset on which the pipeline will be run.
+    workingRepo : `str`
+        The repository in which temporary products will be created. Must be
+        compatible with `dataset`.
+
+    Returns
+    -------
+    metadata : `lsst.daf.base.PropertySet`
+        The full metadata from any Tasks called by this method, or `None`.
+    """
+    # TODO: move doIngestTemplates to this module once DM-11865 resolved
+    rawRepo = get_output_repo(workingRepo, INGESTED_DIR)
+    return doIngestTemplates(rawRepo, rawRepo, dataset.templateLocation)
 
 
 def doIngest(base_repo, raw_dir, refcat_dir):

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -162,13 +162,11 @@ def _process(workingRepo, dataId, parallelization):
 
 
 @_MetricsRecovery
-def _difference(dataset, workingRepo, dataId, parallelization):
+def _difference(workingRepo, dataId, parallelization):
     """Run image differencing on a dataset.
 
     Parameters
     ----------
-    dataset : `lsst.ap.verify.dataset.Dataset`
-        The dataset on which the pipeline will be run.
     workingRepo : `str`
         The repository containing the input and output data.
     dataId : `str`
@@ -182,7 +180,7 @@ def _difference(dataset, workingRepo, dataId, parallelization):
     metadata : `lsst.daf.base.PropertySet`
         The full metadata from any Tasks called by this method, or `None`.
     """
-    return apPipe.doDiffIm(workingRepo, dataset.templateLocation, dataId)
+    return apPipe.doDiffIm(workingRepo, dataId)
 
 
 @_MetricsRecovery
@@ -220,16 +218,13 @@ def _postProcess(workingRepo):
     pass
 
 
-def runApPipe(metricsJob, dataset, workingRepo, parsedCmdLine):
+def runApPipe(metricsJob, workingRepo, parsedCmdLine):
     """Run `ap_pipe` on this object's dataset.
 
     Parameters
     ----------
-    dataset : `lsst.ap.verify.dataset.Dataset`
-        The dataset on which the pipeline will be run.
     workingRepo : `str`
-        The repository in which temporary products will be created. Must be
-        compatible with `dataset`.
+        The repository in which temporary products will be created.
     parsedCmdLine : `argparse.Namespace`
         Command-line arguments, including all arguments supported by `ApPipeParser`.
     metricsJob : `lsst.verify.Job`
@@ -256,7 +251,7 @@ def runApPipe(metricsJob, dataset, workingRepo, parsedCmdLine):
     metadata.combine(_process(metricsJob, workingRepo, dataId, processes))
     log.info('Single-frame processing complete')
 
-    metadata.combine(_difference(metricsJob, dataset, workingRepo, dataId, processes))
+    metadata.combine(_difference(metricsJob, workingRepo, dataId, processes))
     log.info('Image differencing complete')
     metadata.combine(_associate(metricsJob, workingRepo, dataId, processes))
     log.info('Source association complete')

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -275,12 +275,6 @@ def _getApPipeRepos(metadata):
     metadata : `lsst.daf.base.PropertySet`
         A set of metadata to append to.
     """
-    metadata.add("ap_pipe.RAW_DIR", apPipe.ap_pipe.RAW_DIR)
-    metadata.add("ap_pipe.MASTERCAL_DIR", apPipe.ap_pipe.MASTERCAL_DIR)
-    metadata.add("ap_pipe.DEFECT_DIR", apPipe.ap_pipe.DEFECT_DIR)
-    metadata.add("ap_pipe.REFCATS_DIR", apPipe.ap_pipe.REFCATS_DIR)
-    metadata.add("ap_pipe.TEMPLATES_DIR", apPipe.ap_pipe.TEMPLATES_DIR)
-
     metadata.add("ap_pipe.INGESTED_DIR", apPipe.ap_pipe.INGESTED_DIR)
     metadata.add("ap_pipe.CALIBINGESTED_DIR", apPipe.ap_pipe.CALIBINGESTED_DIR)
     metadata.add("ap_pipe.PROCESSED_DIR", apPipe.ap_pipe.PROCESSED_DIR)

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -140,50 +140,6 @@ def _MetricsRecovery(pipelineStep):
 
 
 @_MetricsRecovery
-def _ingestRaws(dataset, workingRepo):
-    """Ingest the raw data for use by LSST.
-
-    The original data directory shall not be modified.
-
-    Parameters
-    ----------
-    dataset : `lsst.ap.verify.dataset.Dataset`
-        The dataset on which the pipeline will be run.
-    workingRepo : `str`
-        The repository in which temporary products will be created. Must be
-        compatible with `dataset`.
-
-    Returns
-    -------
-    metadata : `lsst.daf.base.PropertySet`
-        The full metadata from any Tasks called by this method, or `None`.
-    """
-    return apPipe.doIngest(workingRepo, dataset.rawLocation, dataset.refcatsLocation)
-
-
-@_MetricsRecovery
-def _ingestCalibs(dataset, workingRepo):
-    """Ingest the raw calibrations for use by LSST.
-
-    The original calibration directory shall not be modified.
-
-    Parameters
-    ----------
-    dataset : `lsst.ap.verify.dataset.Dataset`
-        The dataset on which the pipeline will be run.
-    workingRepo : `str`
-        The repository in which temporary products will be created. Must be
-        compatible with `dataset`.
-
-    Returns
-    -------
-    metadata : `lsst.daf.base.PropertySet`
-        The full metadata from any Tasks called by this method, or `None`.
-    """
-    return apPipe.doIngestCalibs(workingRepo, dataset.calibLocation, dataset.defectLocation)
-
-
-@_MetricsRecovery
 def _process(workingRepo, dataId, parallelization):
     """Run single-frame processing on a dataset.
 
@@ -292,12 +248,8 @@ def runApPipe(metricsJob, dataset, workingRepo, parsedCmdLine):
     """
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipe')
 
-    # Easiest way to defend against None return values
     metadata = dafBase.PropertySet()
-    metadata.combine(_ingestRaws(metricsJob, dataset, workingRepo))
-    metadata.combine(_ingestCalibs(metricsJob, dataset, workingRepo))
     _getApPipeRepos(metadata)
-    log.info('Data ingested')
 
     dataId = parsedCmdLine.dataId
     processes = parsedCmdLine.processes

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -72,7 +72,7 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
         outputDir = os.path.join(testDir, 'hitsOut')
 
         try:
-            self._testbed.makeOutputRepo(outputDir)
+            self._testbed.makeCompatibleRepo(outputDir)
             self.assertTrue(os.path.exists(outputDir), 'Output directory must exist.')
             self.assertTrue(os.listdir(outputDir), 'Output directory must not be empty.')
             self.assertTrue(os.path.exists(os.path.join(outputDir, '_mapper')),
@@ -94,7 +94,7 @@ class DatasetTestSuite(lsst.utils.tests.TestCase):
             with open(output, 'w') as dummy:
                 dummy.write('This is a test!')
 
-            self._testbed.makeOutputRepo(outputDir)
+            self._testbed.makeCompatibleRepo(outputDir)
             self.assertTrue(os.path.exists(outputDir), 'Output directory must exist.')
             self.assertTrue(os.listdir(outputDir), 'Output directory must not be empty.')
             self.assertTrue(os.path.exists(os.path.join(outputDir, '_mapper')),


### PR DESCRIPTION
This PR moves ingestion out of `pipeline_driver` and into a new module called `ingestion`. The new module is responsible for the entire conversion of raws, calibs, and templates from the dataset format into a Butler repository, including some steps that were previously part of the main `ap_verify` module. The repository is then used for all processing by `pipeline_driver`.

Due to API changes, must be merged simultaneously with lsst-dm/ap_pipe#14.