### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: python
+matrix:
+  include:
+    - python: '3.6'
+      install:
+      - pip install flake8
+      script: flake8
+

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -61,7 +61,8 @@ class _VerifyApParser(argparse.ArgumentParser):
                           help='The source of data to pass through the pipeline.')
 
         output = self.add_mutually_exclusive_group(required=True)
-        output.add_argument('--output', help='The location of the workspace to use for pipeline repositories.')
+        output.add_argument('--output',
+                            help='The location of the workspace to use for pipeline repositories.')
         output.add_argument(
             '--rerun', metavar='OUTPUT',
             type=_FormattedType('[^:]+',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[flake8]
+max-line-length = 110
+ignore = E133, E226, E228, E251, N802, N803, N806
+exclude =
+  bin,
+  config,
+  doc,
+  **/*/__init__.py,
+  **/*/version.py,
+  tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+  # For some reason pytest-flake8 doesn't use `exclude` consistently
+  bin/*.py ALL
+  config/*.py ALL
+  doc/*.py ALL

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -34,6 +34,8 @@ import unittest
 from urllib.request import url2pathname
 
 import lsst.utils.tests
+from lsst.daf.persistence import Butler
+import lsst.obs.test
 from lsst.ap.verify.workspace import Workspace
 
 
@@ -78,6 +80,19 @@ class WorkspaceTestSuite(lsst.utils.tests.TestCase):
         self._assertInDir(url2pathname(self._testbed.calibRepo), root)
         self._assertInDir(url2pathname(self._testbed.templateRepo), root)
         self._assertInDir(url2pathname(self._testbed.outputRepo), root)
+
+    def testButlers(self):
+        with self.assertRaises(EnvironmentError):
+            self._testbed.workButler
+
+        with self.assertRaises(RuntimeError):
+            self._testbed.analysisButler
+
+        # Give `workButler` a well-defined input
+        Butler(outputs={'root': self._testbed.dataRepo, 'mapper': lsst.obs.test.TestMapper})
+
+        self._testbed.workButler
+        self._testbed.analysisButler
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 
 # Needed for urllib
 from future.standard_library import install_aliases
-install_aliases()
+install_aliases()  # noqa: E402
 
 import os
 import shutil


### PR DESCRIPTION
This is a minimal set of changes needed for `ap_verify` to be able to call `ap_pipe`'s API introduced in lsst-dm/ap_pipe#17. In particular, I did not attempt to change the basic architecture of `pipeline_driver`, as the best design depends on the as-yet nebulous requirements for `ap_verify` (in particular, the desired behavior in the event of pipeline failures).