### PR TITLE
DM-13042: allow ap_verify to run under SLURM

### DIFF
--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -77,6 +77,9 @@ class MetricsParser(argparse.ArgumentParser):
     def __init__(self):
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
+        self.add_argument('--metrics-file', default='ap_verify.verify.json',
+                          help='The file to which to output metrics in lsst.verify format. '
+                               'Defaults to ap_verify.verify.json.')
         self.add_argument('--silent', dest='submitMetrics', action='store_false',
                           help='Do NOT submit metrics to SQuaSH (not yet implemented).')
         # Config info we don't want on the command line
@@ -104,6 +107,7 @@ class AutoJob:
         self._job = lsst.verify.Job.load_metrics_package()
         # TODO: add Job metadata (camera, filter, etc.) in DM-11321
         self._submitMetrics = args.submitMetrics
+        self._outputFile = args.metrics_file
         self._squashUser = args.user
         self._squashPassword = args.password
         self._squashUrl = args.squashUrl
@@ -150,10 +154,9 @@ class AutoJob:
         """
         log = lsst.log.Log.getLogger('ap.verify.metrics.AutoJob.__exit__')
 
-        outFile = 'ap_verify.verify.json'
         try:
-            self._saveMeasurements(outFile)
-            log.debug('Wrote measurements to %s', outFile)
+            self._saveMeasurements(self._outputFile)
+            log.debug('Wrote measurements to %s', self._outputFile)
         except IOError:
             if excType is None:
                 raise

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -161,7 +161,7 @@ def _associate(pipeline, workspace, dataId, parallelization):
         Parallelization level at which to run underlying task(s).
     """
     dataRef = workspace.workButler.dataRef('calexp', **dataId)
-    pipeline.runDiffIm(dataRef)
+    pipeline.runAssociation(dataRef)
 
 
 def _postProcess(workspace):


### PR DESCRIPTION
This pull request adds a command line argument that lets the user specify the metrics output file produced by `ap_verify`. If the argument is not provided, ap_verify reverts to the old behavior.

This PR also fixes a pipeline bug that was introduced by DM-13163.