### PR TITLE
DM-14359: Fix data ID handling in ap_*

### DIFF
--- a/demo_run.py
+++ b/demo_run.py
@@ -25,8 +25,6 @@
 This is a temporary script, to be removed once ap_pipe can handle multiple dataIds
 """
 
-from __future__ import absolute_import, division, print_function
-
 from collections import defaultdict
 import glob
 import json

--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import
-
 import pkgutil, lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/ap/__init__.py
+++ b/python/lsst/ap/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import
-
 import pkgutil, lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/ap/verify/__init__.py
+++ b/python/lsst/ap/verify/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .version import *
 from .ap_verify import *
 from .ingestion import DatasetIngestConfig

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -27,8 +27,6 @@ In addition to containing ap_verify's main function, this module manages
 command-line argument parsing.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["runApVerify"]
 
 import argparse

--- a/python/lsst/ap/verify/config.py
+++ b/python/lsst/ap/verify/config.py
@@ -21,10 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
-from future.utils import raise_from
-
 from lsst.daf.persistence import Policy
 
 
@@ -54,7 +50,7 @@ class Config(object):
             if not isinstance(datasetMap, Policy):
                 raise TypeError('`datasets` is not a dictionary')
         except (KeyError, TypeError) as e:
-            raise_from(RuntimeError('Invalid config file.'), e)
+            raise RuntimeError('Invalid config file.') from e
 
         try:
             measurementMap = self._allInfo['measurements']
@@ -64,7 +60,7 @@ class Config(object):
             if not isinstance(timingMap, Policy):
                 raise TypeError('`measurements.timing` is not a dictionary')
         except (KeyError, TypeError) as e:
-            raise_from(RuntimeError('Invalid config file.'), e)
+            raise RuntimeError('Invalid config file.') from e
 
 
 # Hack, but I don't know how else to make Config.instance act like a dictionary of config options

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -21,10 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import os
-from future.utils import raise_from
 
 from lsst.daf.persistence import Butler
 import lsst.pex.exceptions as pexExcept
@@ -64,10 +61,9 @@ class Dataset(object):
         try:
             self._dataRootDir = getPackageDir(datasetPackage)
         except pexExcept.NotFoundError as e:
-            raise_from(
-                RuntimeError('Dataset %s requires the %s package, which has not been set up.'
-                             % (datasetId, datasetPackage)),
-                e)
+            error = 'Dataset %s requires the %s package, which has not been set up.' \
+                % (datasetId, datasetPackage)
+            raise RuntimeError(error) from e
         else:
             self._validatePackage()
 

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -27,8 +27,6 @@ This module handles ingestion of a dataset into an appropriate repository, so
 that pipeline code need not be aware of the dataset framework.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["DatasetIngestConfig", "ingestDataset"]
 
 import fnmatch

--- a/python/lsst/ap/verify/measurements/__init__.py
+++ b/python/lsst/ap/verify/measurements/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import
-
 from .compute_metrics import *

--- a/python/lsst/ap/verify/measurements/association.py
+++ b/python/lsst/ap/verify/measurements/association.py
@@ -24,8 +24,6 @@
 """Code for measuring software performance metrics.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["measureNumberNewDiaObjects",
            "measureNumberUnassociatedDiaObjects",
            "measureFractionUpdatedDiaObjects",

--- a/python/lsst/ap/verify/measurements/compute_metrics.py
+++ b/python/lsst/ap/verify/measurements/compute_metrics.py
@@ -27,8 +27,6 @@ The rest of `ap_verify` should access `measurements` through the functions
 defined here, rather than depending on individual measurement functions.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["measureFromMetadata",
            "measureFromButlerRepo",
            "measureFromL1DbSqlite"]

--- a/python/lsst/ap/verify/measurements/profiling.py
+++ b/python/lsst/ap/verify/measurements/profiling.py
@@ -26,8 +26,6 @@
 All measurements assume the necessary information is present in a task's metadata.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["measureRuntime"]
 
 import astropy.units as u

--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -28,8 +28,6 @@ processing of individual measurements. Measurements are handled in the
 ``ap_verify`` module or in the appropriate pipeline step, as appropriate.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["AutoJob", "MetricsParser", "checkSquashReady"]
 
 import argparse

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -29,14 +29,11 @@ that a total pipeline failure still allows some measurements to be
 recovered.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["ApPipeParser", "MeasurementStorageError", "runApPipe"]
 
 import argparse
 import os
 import re
-from future.utils import raise_from
 
 import json
 
@@ -103,9 +100,7 @@ def _updateMetrics(metadata, job):
                 taskJob = Job.deserialize(**json.load(f))
             job += taskJob
     except (IOError, TypeError) as e:
-        raise_from(
-            MeasurementStorageError('Task metadata could not be read; possible downstream bug'),
-            e)
+        raise MeasurementStorageError('Task metadata could not be read; possible downstream bug') from e
 
 
 def _process(pipeline, workspace, dataId, parallelization):
@@ -235,13 +230,9 @@ def _deStringDataId(dataId):
     dataId: `dict` from `str` to any
         The dataId to be cleaned up.
     '''
-    try:
-        basestring
-    except NameError:
-        basestring = str
     integer = re.compile('^\s*[+-]?\d+\s*$')
     for key, value in dataId.items():
-        if isinstance(value, basestring) and integer.match(value) is not None:
+        if isinstance(value, str) and integer.match(value) is not None:
             dataId[key] = int(value)
 
 

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -41,6 +41,7 @@ from future.utils import raise_from
 import json
 
 import lsst.log
+import lsst.daf.persistence as dafPersist
 import lsst.ap.pipe as apPipe
 from lsst.verify import Job
 
@@ -122,8 +123,8 @@ def _process(pipeline, workspace, dataId, parallelization):
     parallelization : `int`
         Parallelization level at which to run underlying task(s).
     """
-    dataRef = workspace.workButler.dataRef('raw', **dataId)
-    pipeline.runProcessCcd(dataRef)
+    for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='raw', dataId=dataId):
+        pipeline.runProcessCcd(dataRef)
 
 
 def _difference(pipeline, workspace, dataId, parallelization):
@@ -141,8 +142,8 @@ def _difference(pipeline, workspace, dataId, parallelization):
     parallelization : `int`
         Parallelization level at which to run underlying task(s).
     """
-    dataRef = workspace.workButler.dataRef('calexp', **dataId)
-    pipeline.runDiffIm(dataRef)
+    for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
+        pipeline.runDiffIm(dataRef)
 
 
 def _associate(pipeline, workspace, dataId, parallelization):
@@ -160,8 +161,8 @@ def _associate(pipeline, workspace, dataId, parallelization):
     parallelization : `int`
         Parallelization level at which to run underlying task(s).
     """
-    dataRef = workspace.workButler.dataRef('calexp', **dataId)
-    pipeline.runAssociation(dataRef)
+    for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
+        pipeline.runAssociation(dataRef)
 
 
 def _postProcess(workspace):

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import stat
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import shlex
 import unittest
 

--- a/tests/test_association.py
+++ b/tests/test_association.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import unittest
 
 import astropy.units as u

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import shutil
 import tempfile

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import shutil
 import tempfile

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -51,8 +51,7 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
 
         cls.testApVerifyData = os.path.join('tests', 'ingestion')
         cls.rawDataId = {'visit': 229388, 'ccdnum': 1}
-        # TODO: butler queries fail without this extra info; related to DM-12672?
-        cls.calibDataId = {'visit': 229388, 'ccdnum': 1, 'filter': 'z', 'date': '2013-09-01'}
+        cls.calibDataId = {'ccdnum': 1, 'filter': 'z', 'calibDate': '2013-09-01'}
         cls.defectDataId = {'path': os.path.join('defects', 'D_n20150105t0115_c23_r2134p01_bpm.fits')}
 
     def setUp(self):
@@ -88,7 +87,7 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
         shutil.rmtree(self._repo, ignore_errors=True)
 
     def _rawButler(self):
-        """Return multiple ways of querying calibration repositories.
+        """Return a way to query calibration repositories.
 
         Returns
         -------
@@ -98,7 +97,7 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
         return dafPersist.Butler(inputs={'root': self._repo, 'mode': 'r'})
 
     def _calibButler(self):
-        """Return multiple ways of querying calibration repositories.
+        """Return a way to query calibration repositories.
 
         Returns
         -------

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -118,6 +118,7 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
 
         butler = self._rawButler()
         self.assertTrue(butler.datasetExists('raw', dataId=IngestionTestSuite.rawDataId))
+        self.assertFalse(_isEmpty(butler, 'raw'))
 
     def testCalibIngest(self):
         """Test that ingesting calibrations adds them to a repository.
@@ -145,7 +146,6 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
         self.assertTrue(butler.datasetExists('defects', dataId=IngestionTestSuite.defectDataId))
 
     @unittest.skip("Ingestion functions cannot handle empty file lists, see DM-13835")
-    @unittest.skip("Dataset enumeration requires specific data keys for date, filter, etc., see DM-12762")
     def testNoFileIngest(self):
         """Test that attempts to ingest nothing do nothing.
         """
@@ -156,9 +156,6 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
 
         butler = self._calibButler()
         self.assertTrue(_isEmpty(butler, 'raw'))
-        self.assertTrue(_isEmpty(butler, 'cpBias'))
-        self.assertTrue(_isEmpty(butler, 'cpFlat'))
-        self.assertTrue(_isEmpty(butler, 'defects'))
 
     # TODO: add unit test for _doIngest(..., badFiles) once DM-13835 resolved
 
@@ -183,6 +180,16 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
 
 def _isEmpty(butler, datasetType):
     """Test that a butler repository contains no objects.
+
+    Parameters
+    ----------
+    datasetType : `str`
+        The type of dataset to search for.
+
+    Notes
+    -----
+    .. warning::
+       Does not work for calib datasets, because they're not discoverable.
     """
     possibleDataRefs = butler.subset(datasetType)
     for dataRef in possibleDataRefs:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -21,8 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import unittest
 
 import numpy as np

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -21,12 +21,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import, division, print_function
-
-# Needed for urllib
-from future.standard_library import install_aliases
-install_aliases()  # noqa: E402
-
 import os
 import shutil
 import tempfile


### PR DESCRIPTION
This PR cleans up the ingestion unit tests and guarantees that the pipeline driver always passes complete data IDs to `ApPipeTask`. It also removes use of `future` and other Python 2/3 compatibility code.

This PR must be merged after lsst/daf_persistence#93.