### PR TITLE
DM-13573: Create command-line ingestion script in ap_verify

### DIFF
--- a/bin.src/ap_verify.py
+++ b/bin.src/ap_verify.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 #
-# LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# This file is part of ap_verify.
 #
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,9 +18,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 from lsst.ap.verify import runApVerify

--- a/bin.src/ingest_dataset.py
+++ b/bin.src/ingest_dataset.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# This file is part of ap_verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from lsst.ap.verify import runIngestion
+
+if __name__ == "__main__":
+    runIngestion()

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -13,9 +13,9 @@ Signature and syntax
 
 The basic call signature of ``ap_verify`` is:
 
-.. code-block:: sh
+.. prompt:: bash
 
-   python ap_verify.py --dataset DATASET --output WORKSPACE --id DATAID
+   ap_verify.py --dataset DATASET --output WORKSPACE --id DATAID
 
 These three arguments (or replacing ``--output`` with ``--rerun``) are mandatory, all others are optional.
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -29,7 +29,7 @@ Using the :ref:`HiTS 2015 <ap_verify_hits2015-package>` dataset as an example, o
 
 .. prompt:: bash
 
-   python ap_verify/bin/ap_verify.py --dataset HiTS2015 --id "visit=54123 ccd=25 filter=g" --output workspaces/hits/ --silent
+   ap_verify.py --dataset HiTS2015 --id "visit=54123 ccd=25 filter=g" --output workspaces/hits/ --silent
 
 Here the inputs are:
 
@@ -40,7 +40,7 @@ while the output is:
 
 * :command:`workspaces/hits/` is the location where the pipeline will create any :ref:`Butler repositories<command-line-task-data-repo-using-uris>` necessary,
 
-. :command:`--silent` disables SQuaSH metrics reporting.
+* :command:`--silent` disables SQuaSH metrics reporting.
 
 This call will create a new directory at :file:`workspaces/hits`, ingest the HiTS data into a new repository based on :file:`<hits-data>/repo/`, then run visit 54123 through the entire AP pipeline.
 
@@ -59,7 +59,7 @@ It is also possible to place a workspace in a subdirectory of a dataset director
 
 .. prompt:: bash
 
-   python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --rerun run1 --id "visit=54123 ccd=25 filter=g" --silent
+   ap_verify.py --dataset HiTS2015 --rerun run1 --id "visit=54123 ccd=25 filter=g" --silent
 
 The :command:`--rerun run1` argument will create a directory at :file:`<hits-data>/rerun/run1/`.
 Since neither :ref:`datasets<ap-verify-datasets-butler>` nor ``ap_verify`` output directories are repositories, the :option:`--rerun <ap_verify.py --rerun>` parameter only superficially resembles the analogous argument for command-line tasks.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -50,13 +50,6 @@ This call will create a new directory at :file:`workspaces/hits`, ingest the HiT
    In particular, only file-based repositories are supported, and compound dataIds cannot be provided.
    See the :ref:`ap-verify-cmd` for details.
 
-.. TODO: remove this note after resolving DM-13042
-
-.. warning::
-
-   ``ap_verify.py`` does not support running multiple instances concurrently.
-   Attempting to run two or more programs, particularly from the same working directory, may cause them to compete for access to the output directories or to overwrite each others' metrics.
-
 .. _ap-verify-run-rerun:
 
 How to Run ap_verify in the Dataset Directory
@@ -95,13 +88,13 @@ Other options from ``ap_verify`` are not available.
 How to Use Measurements of Metrics
 ----------------------------------
 
-After ``ap_verify`` has run, it will produce a file named :file:`ap_verify.verify.json` in the caller's directory.
+After ``ap_verify`` has run, it will produce a file named, by default, :file:`ap_verify.verify.json` in the caller's directory.
+The file name may be customized using the :option:`--metrics-file <ap_verify.py --metrics-file>` command-line argument.
 This file contains metric measurements in `lsst.verify` format, and can be loaded and read as described in the `lsst.verify` documentation or in `SQR-019 <https://sqr-019.lsst.io>`_.
-The file name is currently hard-coded, but may be customizable in a future version.
 
 Unless the :option:`--silent <ap_verify.py --silent>` argument is provided, ``ap_verify`` will also upload measurements to the `SQuaSH service <https://squash.lsst.codes/>`_ on completion.
 See the SQuaSH documentation for details.
 
-If the pipeline is interrupted by a fatal error, completed measurements will be saved to :file:`ap_verify.verify.json` for debugging purposes, but nothing will get sent to SQuaSH.
+If the pipeline is interrupted by a fatal error, completed measurements will be saved to the metrics file for debugging purposes, but nothing will get sent to SQuaSH.
 See the :ref:`error-handling policy <ap-verify-failsafe-partialmetric>` for details.
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -72,6 +72,24 @@ The :command:`--rerun run1` argument will create a directory at :file:`<hits-dat
 Since neither :ref:`datasets<ap-verify-datasets-butler>` nor ``ap_verify`` output directories are repositories, the :option:`--rerun <ap_verify.py --rerun>` parameter only superficially resembles the analogous argument for command-line tasks.
 In particular, ``ap_verify``'s ``--rerun`` does not support repository chaining (as in :command:`--rerun input:output`); the input for ``ap_verify`` will always be determined by the :option:`--dataset <ap_verify.py --dataset>`.
 
+.. _ap-verify-run-ingest:
+
+How to Run Ingestion By Itself
+------------------------------
+
+``ap_verify`` includes a separate program, :command:`ingest_dataset.py`, that ingests datasets but does not run the pipeline on them.
+This is useful if the data need special processing or as a precursor to massive processing runs.
+Running ``ap_verify`` with the same arguments as a previous run of ``ingest_dataset`` will automatically skip ingestion.
+
+Using the :ref:`HiTS 2015 <ap_verify_hits2015-package>` dataset as an example, one can run ``ingest_dataset`` as follows:
+
+.. prompt:: bash
+
+   ingest_dataset.py --dataset HiTS2015 --output workspaces/hits/
+
+The :option:`--dataset <ap_verify.py --dataset>`, :option:`--output <ap_verify.py --output>`, and :option:`--rerun <ap_verify.py --rerun>` arguments behave the same way as for ``ap_verify``.
+Other options from ``ap_verify`` are not available.
+
 .. _ap-verify-results:
 
 How to Use Measurements of Metrics

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -44,17 +44,16 @@ from .measurements import measureFromMetadata, \
 from .workspace import Workspace
 
 
-class _VerifyApParser(argparse.ArgumentParser):
-    """An argument parser for data needed by this script.
+class _InputOutputParser(argparse.ArgumentParser):
+    """An argument parser for program-wide input and output.
+
+    This parser is not complete, and is designed to be passed to another parser
+    using the `parent` parameter.
     """
 
     def __init__(self):
-        argparse.ArgumentParser.__init__(
-            self,
-            description='Executes the LSST DM AP pipeline and analyzes its performance using metrics.',
-            epilog='',
-            parents=[ApPipeParser(), MetricsParser()],
-            add_help=True)
+        # Help and documentation will be handled by main program's parser
+        argparse.ArgumentParser.__init__(self, add_help=False)
         self.add_argument('--dataset', choices=Dataset.getSupportedDatasets(), required=True,
                           help='The source of data to pass through the pipeline.')
 
@@ -68,6 +67,19 @@ class _VerifyApParser(argparse.ArgumentParser):
                                 'You have entered something that appears to be of the form INPUT:OUTPUT. '
                                 'Please specify only OUTPUT.'),
             help='The location of the workspace to use for pipeline repositories, as DATASET/rerun/OUTPUT')
+
+
+class _VerifyApParser(argparse.ArgumentParser):
+    """An argument parser for data needed by this script.
+    """
+
+    def __init__(self):
+        argparse.ArgumentParser.__init__(
+            self,
+            description='Executes the LSST DM AP pipeline and analyzes its performance using metrics.',
+            epilog='',
+            parents=[_InputOutputParser(), ApPipeParser(), MetricsParser()],
+            add_help=True)
 
         self.add_argument('--version', action='version', version='%(prog)s 0.1.0')
 

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -159,12 +159,9 @@ def _measureFinalProperties(metricsJob, metadata, workspace, args):
         All command-line arguments passed to this program, including those
         supported by `lsst.ap.verify.pipeline_driver.ApPipeParser`.
     """
-    # TODO: remove this function's dependency on pipeline_driver (possibly after DM-11372)
+    # TODO: remove this function's dependency on pipeline_driver (DM-13555)
     measurements = []
     measurements.extend(measureFromMetadata(metadata))
-    # In the current version of ap_pipe, DIFFIM_DIR has a parent of
-    # PROCESSED_DIR. This means that a butler created from the DIFFIM_DIR reop
-    # includes data from PROCESSED_DIR.
     measurements.extend(measureFromButlerRepo(workspace.outputRepo, args.dataId))
     measurements.extend(measureFromL1DbSqlite(os.path.join(workspace.outputRepo, "association.db")))
 
@@ -178,9 +175,6 @@ def runApVerify(cmdLine=None):
     This is the main function for ``ap_verify``, and handles logging,
     command-line argument parsing, pipeline execution, and metrics
     generation.
-
-    After this function returns, metrics will be available in a file
-    named :file:`ap_verify.verify.json` in the working directory.
 
     Parameters
     ----------

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -69,7 +69,7 @@ class _InputOutputParser(argparse.ArgumentParser):
             help='The location of the workspace to use for pipeline repositories, as DATASET/rerun/OUTPUT')
 
 
-class _VerifyApParser(argparse.ArgumentParser):
+class _ApVerifyParser(argparse.ArgumentParser):
     """An argument parser for data needed by this script.
     """
 
@@ -191,7 +191,7 @@ def runApVerify(cmdLine=None):
     lsst.log.configure()
     log = lsst.log.Log.getLogger('ap.verify.ap_verify.main')
     # TODO: what is LSST's policy on exceptions escaping into main()?
-    args = _VerifyApParser().parse_args(args=cmdLine)
+    args = _ApVerifyParser().parse_args(args=cmdLine)
     checkSquashReady(args)
     log.debug('Command-line arguments: %s', args)
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -35,11 +35,16 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
 
         Parameters
         ----------
-        commandLine: `str`
+        commandLine : `str`
             a string containing Unix-style command line arguments, but not the
             name of the program
+
+        Returns
+        -------
+        parsed : `argparse.Namespace`
+            The parsed command line.
         """
-        return ap_verify._VerifyApParser().parse_args(shlex.split(commandLine))
+        return ap_verify._ApVerifyParser().parse_args(shlex.split(commandLine))
 
     def testMissing(self):
         """Verify that a command line consisting missing required arguments is rejected.

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -30,7 +30,7 @@ import lsst.ap.verify.ap_verify as ap_verify
 
 class CommandLineTestSuite(lsst.utils.tests.TestCase):
 
-    def _parseString(self, commandLine):
+    def _parseString(self, commandLine, parser=None):
         """Tokenize and parse a command line string.
 
         Parameters
@@ -38,22 +38,34 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
         commandLine : `str`
             a string containing Unix-style command line arguments, but not the
             name of the program
+        parser : `argparse.ArgumentParser`, optional
+            the parser to use. Defaults to ``ap_verify``'s primary parser.
 
         Returns
         -------
         parsed : `argparse.Namespace`
             The parsed command line.
         """
-        return ap_verify._ApVerifyParser().parse_args(shlex.split(commandLine))
+        if not parser:
+            parser = ap_verify._ApVerifyParser()
 
-    def testMissing(self):
+        return parser.parse_args(shlex.split(commandLine))
+
+    def testMissingMain(self):
         """Verify that a command line consisting missing required arguments is rejected.
         """
         args = '--dataset HiTS2015 --output tests/output/foo'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 
-    def testMinimum(self):
+    def testMissingIngest(self):
+        """Verify that a command line consisting missing required arguments is rejected.
+        """
+        args = '--dataset HiTS2015'
+        with self.assertRaises(SystemExit):
+            self._parseString(args, ap_verify._IngestOnlyParser())
+
+    def testMinimumMain(self):
         """Verify that a command line consisting only of required arguments parses correctly.
         """
         args = '--dataset HiTS2015 --output tests/output/foo --id "visit=54123"'
@@ -61,6 +73,14 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
         self.assertIn('dataset', dir(parsed))
         self.assertIn('output', dir(parsed))
         self.assertIn('dataId', dir(parsed))
+
+    def testMinimumIngest(self):
+        """Verify that a command line consisting only of required arguments parses correctly.
+        """
+        args = '--dataset HiTS2015 --output tests/output/foo'
+        parsed = self._parseString(args, ap_verify._IngestOnlyParser())
+        self.assertIn('dataset', dir(parsed))
+        self.assertIn('output', dir(parsed))
 
     def testRerun(self):
         """Verify that a command line with reruns is handled correctly.
@@ -91,12 +111,19 @@ class CommandLineTestSuite(lsst.utils.tests.TestCase):
         with self.assertRaises(SystemExit):
             self._parseString(args)
 
-    def testBadKey(self):
+    def testBadKeyMain(self):
         """Verify that a command line with unsupported arguments is rejected.
         """
         args = '--dataset HiTS2015 --output tests/output/foo --id "visit=54123" --clobber'
         with self.assertRaises(SystemExit):
             self._parseString(args)
+
+    def testBadKeyIngest(self):
+        """Verify that a command line with unsupported arguments is rejected.
+        """
+        args = '--dataset HiTS2015 --output tests/output/foo --id "visit=54123"'
+        with self.assertRaises(SystemExit):
+            self._parseString(args, ap_verify._IngestOnlyParser())
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR creates an ingestion script in (with an unfortunate amount of code duplication) in `ap_verify`. It also fixes some code and documentation errors that crept in through past work.