### PR TITLE
DM-13835: Cannot ingest empty data

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -438,7 +438,11 @@ def _runIngestTask(task, args):
         The command-line arguments for ``task``. Must be compatible with ``task.ArgumentParser``.
     """
     argumentParser = task.ArgumentParser(name=task.getName())
-    parsedCmd = argumentParser.parse_args(config=task.config, args=args)
+    try:
+        parsedCmd = argumentParser.parse_args(config=task.config, args=args)
+    except SystemExit as e:
+        # SystemExit is not an appropriate response when the arguments aren't user-supplied
+        raise ValueError("Invalid ingestion arguments: %s" % args) from e
     task.run(parsedCmd)
 
 

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -31,6 +31,7 @@ __all__ = ["DatasetIngestConfig", "ingestDataset"]
 
 import fnmatch
 import os
+import pathlib
 import tarfile
 from glob import glob
 import sqlite3
@@ -166,10 +167,8 @@ class DatasetIngestTask(pipeBase.Task):
             ``obs`` package as this task's subtasks.
         """
         dataset.makeCompatibleRepo(workspace.dataRepo)
-        if not os.path.isdir(workspace.calibRepo):
-            os.mkdir(workspace.calibRepo)
-        if not os.path.isdir(workspace.templateRepo):
-            os.mkdir(workspace.templateRepo)
+        pathlib.Path(workspace.calibRepo).mkdir(parents=True, exist_ok=True)
+        pathlib.Path(workspace.templateRepo).mkdir(parents=True, exist_ok=True)
 
     def _ingestRaws(self, dataset, workspace):
         """Ingest the science data for use by LSST.
@@ -321,9 +320,6 @@ class DatasetIngestTask(pipeBase.Task):
         if os.path.exists(os.path.join(workspace.calibRepo, "defects")):
             self.log.info("Defects were previously ingested, skipping...")
         else:
-            if not os.path.isdir(workspace.calibRepo):
-                os.mkdir(workspace.calibRepo)
-
             if self.config.defectTarball:
                 self.log.info("Ingesting defects...")
                 defectFile = os.path.join(dataset.defectLocation, self.config.defectTarball)
@@ -355,8 +351,7 @@ class DatasetIngestTask(pipeBase.Task):
         defectDir = os.path.join(calibRepo, "defects")
         with tarfile.open(defectTarball, "r") as opened:
             if opened.getNames():
-                if not os.path.isdir(defectDir):
-                    os.mkdir(defectDir)
+                pathlib.Path(defectDir).mkdir(parents=True, exist_ok=True)
                 opened.extractall(defectDir)
             else:
                 raise RuntimeError("Defect archive %s is empty." % defectTarball)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -137,14 +137,15 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
             # queryMetadata does not work on calibs
         self.assertFalse(butler.datasetExists('flat', filter='z'))
 
-    @unittest.skip("Ingestion functions cannot handle empty file lists, see DM-13835")
     def testNoFileIngest(self):
-        """Test that attempts to ingest nothing do nothing.
+        """Test that attempts to ingest nothing raise an exception.
         """
         files = []
 
-        self._task._doIngest(self._repo, files, [])
-        self._task._doIngestCalibs(self._repo, self._calibRepo, files)
+        with self.assertRaises(RuntimeError):
+            self._task._doIngest(self._repo, files, [])
+        with self.assertRaises(RuntimeError):
+            self._task._doIngestCalibs(self._repo, self._calibRepo, files)
 
         butler = self._calibButler()
         self.assertTrue(_isEmpty(butler, 'raw'))

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -46,6 +46,15 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
         cls.testApVerifyData = os.path.join('tests', 'ingestion')
         cls.rawDataId = {'visit': 229388, 'ccdnum': 1}
 
+        cls.rawData = [{'file': 'raw_v1_fg.fits.gz', 'visit': 890104911, 'filter': 'g', 'exptime': 15.0},
+                       {'file': 'raw_v2_fg.fits.gz', 'visit': 890106021, 'filter': 'g', 'exptime': 15.0},
+                       {'file': 'raw_v3_fr.fits.gz', 'visit': 890880321, 'filter': 'r', 'exptime': 15.0},
+                       ]
+        cls.calibData = [{'type': 'bias', 'file': 'bias.fits.gz', 'filter': 'None'},
+                         {'type': 'flat', 'file': 'flat_fg.fits.gz', 'filter': 'g'},
+                         {'type': 'flat', 'file': 'flat_fr.fits.gz', 'filter': 'r'},
+                         ]
+
     def setUp(self):
         self._repo = tempfile.mkdtemp()
         self._calibRepo = os.path.join(self._repo, 'calibs')
@@ -100,16 +109,12 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
     def testDataIngest(self):
         """Test that ingesting a science image adds it to a repository.
         """
-        rawData = [{'file': 'raw_v1_fg.fits.gz', 'visit': 890104911, 'filter': 'g', 'exptime': 15.0},
-                   {'file': 'raw_v2_fg.fits.gz', 'visit': 890106021, 'filter': 'g', 'exptime': 15.0},
-                   {'file': 'raw_v3_fr.fits.gz', 'visit': 890880321, 'filter': 'r', 'exptime': 15.0},
-                   ]
         testDir = os.path.join(IngestionTestSuite.testData, 'raw')
-        files = [os.path.join(testDir, datum['file']) for datum in rawData]
+        files = [os.path.join(testDir, datum['file']) for datum in IngestionTestSuite.rawData]
         self._task._doIngest(self._repo, files, [])
 
         butler = self._rawButler()
-        for datum in rawData:
+        for datum in IngestionTestSuite.rawData:
             dataId = {'visit': datum['visit']}
             self.assertTrue(butler.datasetExists('raw', dataId))
             self.assertEqual(butler.queryMetadata('raw', 'filter', dataId),
@@ -122,17 +127,13 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
     def testCalibIngest(self):
         """Test that ingesting calibrations adds them to a repository.
         """
-        calibData = [{'type': 'bias', 'file': 'bias.fits.gz', 'filter': 'None'},
-                     {'type': 'flat', 'file': 'flat_fg.fits.gz', 'filter': 'g'},
-                     {'type': 'flat', 'file': 'flat_fr.fits.gz', 'filter': 'r'},
-                     ]
         files = [os.path.join(IngestionTestSuite.testData, datum['type'], datum['file'])
-                 for datum in calibData]
+                 for datum in IngestionTestSuite.calibData]
 
         self._task._doIngestCalibs(self._repo, self._calibRepo, files)
 
         butler = self._calibButler()
-        for datum in calibData:
+        for datum in IngestionTestSuite.calibData:
             self.assertTrue(butler.datasetExists(datum['type'], filter=datum['filter']))
             # queryMetadata does not work on calibs
         self.assertFalse(butler.datasetExists('flat', filter='z'))

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -151,7 +151,19 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
         butler = self._calibButler()
         self.assertTrue(_isEmpty(butler, 'raw'))
 
-    # TODO: add unit test for _doIngest(..., badFiles) once DM-13835 resolved
+    def testBadFileIngest(self):
+        """Test that ingestion of raw data ignores blacklisted files.
+        """
+        badFiles = ['raw_v2_fg.fits.gz']
+
+        testDir = os.path.join(IngestionTestSuite.testData, 'raw')
+        files = [os.path.join(testDir, datum['file']) for datum in IngestionTestSuite.rawData]
+        self._task._doIngest(self._repo, files, badFiles)
+
+        butler = self._rawButler()
+        for datum in IngestionTestSuite.rawData:
+            dataId = {'visit': datum['visit']}
+            self.assertEqual(butler.datasetExists('raw', dataId), datum['file'] not in badFiles)
 
     def testFindMatchingFiles(self):
         """Test that _findMatchingFiles finds the desired files.


### PR DESCRIPTION
This PR changes the behavior of `DatasetIngestTask`'s private methods from crashing to raising a specific exception. It also adds a unit test that could not be implemented because of this bug (at least, not while we were still using `testdata_decam`).