### PR TITLE
DM-14847: Missing keys in association DB

### DIFF
--- a/python/lsst/ap/verify/measurements/association.py
+++ b/python/lsst/ap/verify/measurements/association.py
@@ -220,7 +220,7 @@ def measureTotalUnassociatedDiaObjects(dbCursor, metricName):
     """
 
     dbCursor.execute("SELECT count(*) FROM dia_objects "
-                     "WHERE n_dia_sources = 1")
+                     "WHERE nDiaSources = 1")
     (nUnassociatedDiaObjects,) = dbCursor.fetchall()[0]
 
     meas = lsst.verify.Measurement(

--- a/tests/test_association.py
+++ b/tests/test_association.py
@@ -103,7 +103,7 @@ def createTestPoints(pointLocsDeg,
                 np.random.rand() * 360 * afwGeom.degrees,
                 np.random.rand() * scatterArcsec * afwGeom.arcseconds)
         if indexerIds is not None:
-            src['indexer_id'] = indexerIds[src_idx]
+            src['pixelId'] = indexerIds[src_idx]
         if associatedIds is not None:
             src['diaObjectId'] = associatedIds[src_idx]
         src.setCoord(coord)
@@ -156,7 +156,7 @@ class MeasureAssociationTestSuite(lsst.utils.tests.TestCase):
                           range(self.numTestDiaObjects)],
             schema=make_minimal_dia_object_schema(['r']))
         for diaObject in diaObjects:
-            diaObject['n_dia_sources'] = 1
+            diaObject['nDiaSources'] = 1
         assocDb.store_dia_objects(diaObjects, True)
         assocDb.close()
 


### PR DESCRIPTION
This PR updates association database queries in `ap_verify` to compensate for lsst-dm/ap_association#17.