### PR TITLE
DM-14742: Let ap_verify run ap_pipe with dataset-specific configs

### DIFF
--- a/doc/lsst.ap.verify/datasets-creation.rst
+++ b/doc/lsst.ap.verify/datasets-creation.rst
@@ -57,6 +57,9 @@ Each dataset's :file:`config` directory should contain a :ref:`task config file<
 The file typically contains filenames or file patterns specific to the dataset.
 In particular, defect files and reference catalogs are ignored by default and need to be explicitly named.
 
+Each :file:`config` directory may contain a task config file named :file:`apPipe.py`, specifying an `lsst.ap.pipe.ApPipeConfig`.
+The file contains pipeline flags specific to the dataset, such as the available reference catalogs or information about how its image differencing templates were generated.
+
 Configuration settings specific to an instrument rather than a dataset should be handled with ordinary :ref:`configuration override files<command-line-task-config-howto-obs>`.
 
 .. _ap-verify-datasets-creation-obs:

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -409,7 +409,8 @@ class DatasetIngestTask(pipeBase.Task):
         for refcatName, tarball in self.config.refcats.items():
             tarball = os.path.join(refcats, tarball)
             refcatDir = os.path.join(repo, "ref_cats", refcatName)
-            tarfile.open(tarball, "r").extractall(refcatDir)
+            with tarfile.open(tarball, "r") as opened:
+                opened.extractall(refcatDir)
 
 
 def ingestDataset(dataset, workspace):

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -145,33 +145,12 @@ class DatasetIngestTask(pipeBase.Task):
             If the repositories already exist, they must support the same
             ``obs`` package as this task's subtasks.
         """
-        self._makeRepos(dataset, workspace)
+        dataset.makeCompatibleRepo(workspace.dataRepo)
         self._ingestRaws(dataset, workspace)
         self._ingestCalibs(dataset, workspace)
         self._ingestDefects(dataset, workspace)
         self._ingestRefcats(dataset, workspace)
         self._copyConfigs(dataset, workspace)
-
-    def _makeRepos(self, dataset, workspace):
-        """Create empty repositories to ingest into.
-
-        After this method returns, all repositories mentioned by ``workspace``
-        except ``workspace.outputRepo`` shall be valid repositories compatible
-        with ``dataset``. They may be empty.
-
-        Parameters
-        ----------
-        dataset : `lsst.ap.verify.dataset.Dataset`
-            The dataset to be ingested.
-        workspace : `lsst.ap.verify.workspace.Workspace`
-            The abstract location where ingestion repositories will be created.
-            If the repositories already exist, they must support the same
-            ``obs`` package as this task's subtasks.
-        """
-        dataset.makeCompatibleRepo(workspace.dataRepo)
-        pathlib.Path(workspace.calibRepo).mkdir(parents=True, exist_ok=True)
-        pathlib.Path(workspace.templateRepo).mkdir(parents=True, exist_ok=True)
-        pathlib.Path(workspace.configDir).mkdir(parents=True, exist_ok=True)
 
     def _ingestRaws(self, dataset, workspace):
         """Ingest the science data for use by LSST.

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -262,7 +262,7 @@ def _deStringDataId(dataId):
     dataId: `dict` from `str` to any
         The dataId to be cleaned up.
     '''
-    integer = re.compile('^\s*[+-]?\d+\s*$')
+    integer = re.compile(r'^\s*[+-]?\d+\s*$')
     for key, value in dataId.items():
         if isinstance(value, str) and integer.match(value) is not None:
             dataId[key] = int(value)

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -61,6 +61,12 @@ class Workspace:
         self._analysisButler = None
 
     @property
+    def configDir(self):
+        """The location of a directory containing custom Task config files for use with the data.
+        """
+        return os.path.join(self._location, 'config')
+
+    @property
     def dataRepo(self):
         """The URI to a Butler repo for science data (`str`, read-only).
         """

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -22,6 +22,7 @@
 #
 
 import os
+import pathlib
 import stat
 
 import lsst.daf.persistence as dafPersist
@@ -30,10 +31,10 @@ import lsst.daf.persistence as dafPersist
 class Workspace:
     """A directory used by ``ap_verify`` to handle data.
 
-    Any object of this class represents a plan for organizing a working
-    directory. At present, constructing a Workspace does not initialize its
-    repositories; for compatibility reasons, this is best deferred to
-    individual tasks.
+    Any object of this class represents a working directory containing
+    (possibly empty) subdirectories for repositories. At present, constructing
+    a Workspace does not *initialize* its repositories; for compatibility
+    reasons, this is best deferred to individual tasks.
 
     Parameters
     ----------
@@ -48,14 +49,17 @@ class Workspace:
     """
 
     def __init__(self, location):
-        # Can't use exceptions to reliably distinguish existing directory from other cases in Python 2
-        if os.path.isdir(location):
-            if not os.access(location, os.R_OK | os.W_OK):
-                raise IOError('Workspace % cannot be read.' % location)
-        else:
-            os.makedirs(location, stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
-
         self._location = location
+
+        mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH  # a+r, u+rwx
+        kwargs = {"parents": True, "exist_ok": True, "mode": mode}
+        pathlib.Path(self._location).mkdir(**kwargs)
+        pathlib.Path(self.configDir).mkdir(**kwargs)
+        pathlib.Path(self.dataRepo).mkdir(**kwargs)
+        pathlib.Path(self.calibRepo).mkdir(**kwargs)
+        pathlib.Path(self.templateRepo).mkdir(**kwargs)
+        pathlib.Path(self.outputRepo).mkdir(**kwargs)
+
         # Lazy evaluation to optimize workButler and analysisButler
         self._workButler = None
         self._analysisButler = None

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -67,6 +67,7 @@ class WorkspaceTestSuite(lsst.utils.tests.TestCase):
         The exact repository locations are not tested, as they are likely to change.
         """
         root = self._testWorkspace
+        self._assertInDir(self._testbed.configDir, root)
         # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
         self._assertInDir(url2pathname(self._testbed.dataRepo), root)
         self._assertInDir(url2pathname(self._testbed.calibRepo), root)


### PR DESCRIPTION
This PR makes a number of minor improvements to `ap_verify`, adds a unit test suite for the `pipeline_driver` module, and adds code to let `ap_verify`'s instance of `ApPipeTask` use both obs package overrides and any data-specific configs packaged with a dataset. The changes may be easier to understand commit-by-commit.

Note that while this PR would have been much simpler if `pipeline_driver` simply called `ApPipeTask.parseAndRun`, there are some design decisions that need to be made before we can change the driver's architecture. Any such changes are well outside the scope of this ticket.