### PR TITLE
DM-13492: Remove --rerun argument for ap_verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ A basic run on HiTS data:
 
     python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --output workspace/hits/ --dataIdString "visit=54123"
 
-This will create a workspace (a Butler repository) in `workspace/hits` based on `<hits-data>/data/`, ingest the HiTS data into it, then run visit 54123 through the entire AP pipeline. `ap_verify` also supports the `--rerun` system:
-
-    python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --rerun run1 --dataIdString "visit=54123"
-
-This will create a workspace in `<hits-data>/rerun/run1/`. Since datasets are not, in general, repositories, many of the complexities of `--rerun` for Tasks (e.g., always using the highest-level repository) do not apply. In addition, the `--rerun` argument does not support input directories; the input for `ap_verify` will always be determined by the `--dataset`.
+This will create a workspace (a Butler repository) in `workspace/hits` based on `<hits-data>/data/`, ingest the HiTS data into it, then run visit 54123 through the entire AP pipeline.
 
 ### Optional Arguments
 

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -17,7 +17,7 @@ The basic call signature of ``ap_verify`` is:
 
    ap_verify.py --dataset DATASET --output WORKSPACE --id DATAID
 
-These three arguments (or replacing ``--output`` with ``--rerun``) are mandatory, all others are optional.
+These three arguments are mandatory, all others are optional.
 
 Status code
 ===========
@@ -28,7 +28,7 @@ If the pipeline fails, the status code will be an interpreter-dependent nonzero 
 Named arguments
 ===============
 
-Required arguments are :option:`--dataset`, :option:`--id`, and exactly one of :option:`--output` or :option:`--rerun`.
+Required arguments are :option:`--dataset`, :option:`--id`, and :option:`--output`.
 
 .. option:: --id <dataId>
 
@@ -82,28 +82,10 @@ Required arguments are :option:`--dataset`, :option:`--id`, and exactly one of :
 
    **Output and intermediate product path.**
 
-   The output argument or :option:`--rerun` is required for all ``ap_verify`` runs except when using :option:`--help` or :option:`--version`.
+   The output argument is required for all ``ap_verify`` runs except when using :option:`--help` or :option:`--version`.
 
    The workspace will be created if it does not exist, and will contain both input and output repositories required for processing the data.
    The path may be absolute or relative to the current working directory.
-
-   ``--output`` may not be used with the :option:`--rerun` argument.
-
-   See :ref:`command-line-task-data-repo-howto` for background.
-
-   .. TODO: Rework or remove --rerun (DM-13492)
-
-.. option:: --rerun <workspace_dir>
-
-   **Specify output "rerun".**
-
-   The rerun or :option:`--output` is required for all ``ap_verify`` runs except when using :option:`--help` or :option:`--version`.
-
-   For ``ap_verify``, a rerun is a workspace directory relative to the dataset directory (as determined by :option:`--dataset`).
-   This is different from command-line task reruns, which are output repositories chained to an input repository.
-   An input rerun cannot be specified.
-
-   ``--rerun`` may not be used with the :option:`--output` argument.
 
 .. option:: --silent
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -50,21 +50,6 @@ This call will create a new directory at :file:`workspaces/hits`, ingest the HiT
    In particular, only file-based repositories are supported, and compound dataIds cannot be provided.
    See the :ref:`ap-verify-cmd` for details.
 
-.. _ap-verify-run-rerun:
-
-How to Run ap_verify in the Dataset Directory
----------------------------------------------
-
-It is also possible to place a workspace in a subdirectory of a dataset directory. The syntax for this mode is:
-
-.. prompt:: bash
-
-   ap_verify.py --dataset HiTS2015 --rerun run1 --id "visit=54123 ccdnum=25 filter=g" --silent
-
-The :command:`--rerun run1` argument will create a directory at :file:`<hits-data>/rerun/run1/`.
-Since neither :ref:`datasets<ap-verify-datasets-butler>` nor ``ap_verify`` output directories are repositories, the :option:`--rerun <ap_verify.py --rerun>` parameter only superficially resembles the analogous argument for command-line tasks.
-In particular, ``ap_verify``'s ``--rerun`` does not support repository chaining (as in :command:`--rerun input:output`); the input for ``ap_verify`` will always be determined by the :option:`--dataset <ap_verify.py --dataset>`.
-
 .. _ap-verify-run-ingest:
 
 How to Run Ingestion By Itself
@@ -80,7 +65,7 @@ Using the :ref:`HiTS 2015 <ap_verify_hits2015-package>` dataset as an example, o
 
    ingest_dataset.py --dataset HiTS2015 --output workspaces/hits/
 
-The :option:`--dataset <ap_verify.py --dataset>`, :option:`--output <ap_verify.py --output>`, and :option:`--rerun <ap_verify.py --rerun>` arguments behave the same way as for ``ap_verify``.
+The :option:`--dataset <ap_verify.py --dataset>` and :option:`--output <ap_verify.py --output>` arguments behave the same way as for ``ap_verify``.
 Other options from ``ap_verify`` are not available.
 
 .. _ap-verify-results:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -84,29 +84,6 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         self.assertIn('dataset', dir(parsed))
         self.assertIn('output', dir(parsed))
 
-    def testRerun(self):
-        """Verify that a command line with reruns is handled correctly.
-        """
-        args = '--dataset %s --rerun me --id "visit=54123"' % CommandLineTestSuite.datasetKey
-        parsed = self._parseString(args)
-        out = ap_verify._getOutputDir('non_lsst_repo/', parsed.output, parsed.rerun)
-        self.assertEqual(out, 'non_lsst_repo/rerun/me')
-
-    def testRerunInput(self):
-        """Verify that a command line trying to redirect input is rejected.
-        """
-        args = '--dataset %s --rerun from:to --id "visit=54123"' % CommandLineTestSuite.datasetKey
-        with self.assertRaises(SystemExit):
-            self._parseString(args)
-
-    def testTwoOutputs(self):
-        """Verify that a command line with both --output and --rerun is rejected.
-        """
-        args = '--dataset %s --output tests/output/foo --rerun me --id "visit=54123"' \
-            % CommandLineTestSuite.datasetKey
-        with self.assertRaises(SystemExit):
-            self._parseString(args)
-
     def testBadDataset(self):
         """Verify that a command line with an unregistered dataset is rejected.
         """


### PR DESCRIPTION
This PR removes the `--rerun` argument from all `ap_verify` code, as well as all references to it in the documentation.