### PR TITLE
DM-15142: Create CI-sized DECam Dataset

### DIFF
--- a/config/dataset_config.yaml
+++ b/config/dataset_config.yaml
@@ -1,6 +1,7 @@
 ---
 datasets:
     HiTS2015: ap_verify_hits2015
+    CI-HiTS2015: ap_verify_ci_hits2015
 measurements:
     timing:
         apPipe:ccdProcessor: pipe_tasks.ProcessCcdTime

--- a/doc/lsst.ap.verify/datasets-install.rst
+++ b/doc/lsst.ap.verify/datasets-install.rst
@@ -22,19 +22,15 @@ EUPS is included in the Stack installation.
 Installation Procedure
 ----------------------
 
-Use Git LFS to clone the desired dataset's GitHub repository.
-To get the URL, see the :ref:`package documentation<ap-verify-datasets-index>` for the dataset in question.
-
-Once the dataset has been installed, use :command:`eups declare` to register the downloaded directory.
-The product name given to EUPS must match the repository name; the version can be anything.
-It is also possible to register the dataset using :command:`setup`, but this is recommended only for temporary tests.
+Use the `LSST Software Build Tool <https://developer.lsst.io/stack/lsstsw.html>`_ to request the dataset by its package name.
+A :ref:`list of existing datasets <ap-verify-datasets-index>` is maintained as part of this documentation.
+Because of their large size (typically hundreds of GB), datasets are *never* installed as a dependency of another package; they must be requested explicitly.
 
 For example, to install the :ref:`HiTS 2015 <ap_verify_hits2015-package>` dataset,
 
 .. prompt:: bash
 
-   $ git clone https://github.com/lsst/ap_verify_hits2015 mydata
-   $ eups declare -r mydata ap_verify_hits2015 v1
+   rebuild -u ap_verify_hits2015
 
 Once this is done, ``ap_verify`` will be able to find the HiTS data upon request.
 

--- a/doc/lsst.ap.verify/datasets.rst
+++ b/doc/lsst.ap.verify/datasets.rst
@@ -32,6 +32,7 @@ Existing Datasets
 -----------------
 
 * :ref:`HiTS2015 <ap_verify_hits2015-package>`
+* :ref:`HiTS2015 CI Subset <ap_verify_ci_hits2015-package>`
 
 ..
    TODO: switch to toctree once these docs included in pipelines.lsst.io
@@ -39,4 +40,5 @@ Existing Datasets
       :maxdepth: 1
 
       ../../packages/ap_verify_hits2015/index.rst
+      ../../packages/ap_verify_ci_hits2015/index.rst
 

--- a/ups/ap_verify.table
+++ b/ups/ap_verify.table
@@ -9,8 +9,11 @@ setupRequired(verify)
 setupRequired(ap_pipe)
 
 setupOptional(ap_verify_testdata)
-setupOptional(ap_verify_hits2015)
 setupOptional(obs_test)
+
+# Datasets other than ap_verify_testdata must be set up manually
+#     to avoid being inadvertently downloaded by lsstsw
+# See the Sphinx docs for known datasets
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
This PR registers `ap_verify_ci_hits2015` with `ap_verify` and adds it to the documentation's list of known datasets. It also updates dataset installation instructions in response to lsst/repos#37.