### PR TITLE
DM-15096: Cannot reuse association database with ApPipeTask reruns

### DIFF
--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -30,7 +30,6 @@ command-line argument parsing.
 __all__ = ["runApVerify", "runIngestion"]
 
 import argparse
-import os
 import re
 
 import lsst.log
@@ -153,11 +152,10 @@ def _measureFinalProperties(metricsJob, metadata, workspace, args):
         All command-line arguments passed to this program, including those
         supported by `lsst.ap.verify.pipeline_driver.ApPipeParser`.
     """
-    # TODO: remove this function's dependency on pipeline_driver (DM-13555)
     measurements = []
     measurements.extend(measureFromMetadata(metadata))
     measurements.extend(measureFromButlerRepo(workspace.outputRepo, args.dataId))
-    measurements.extend(measureFromL1DbSqlite(os.path.join(workspace.outputRepo, "association.db")))
+    measurements.extend(measureFromL1DbSqlite(workspace.dbLocation))
 
     for measurement in measurements:
         metricsJob.measurements.insert(measurement)

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -39,6 +39,7 @@ import json
 
 import lsst.log
 import lsst.daf.persistence as dafPersist
+from lsst.ap.association import AssociationDBSqliteTask
 import lsst.ap.pipe as apPipe
 from lsst.verify import Job
 
@@ -242,6 +243,9 @@ def _getConfig(workspace):
     packageDir = lsst.utils.getPackageDir(mapper.getPackageName())
 
     config = apPipe.ApPipeTask.ConfigClass()
+    # Equivalent to task-level default for ap_verify
+    config.associator.level1_db.retarget(AssociationDBSqliteTask)
+    config.associator.level1_db.db_name = workspace.dbLocation
     for path in [
         os.path.join(packageDir, 'config'),
         os.path.join(packageDir, 'config', mapper.getCameraName()),

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -95,6 +95,16 @@ class Workspace:
         return os.path.join(self._location, 'output')
 
     @property
+    def dbLocation(self):
+        """The default location of the source association database to be
+        created or updated by the pipeline (`str`, read-only).
+
+        Shall be a filename to a database file suitable
+        for `AssociationDBSqliteTask`.
+        """
+        return os.path.join(self._location, 'association.db')
+
+    @property
     def workButler(self):
         """A Butler that can produce pipeline inputs and outputs
         (`lsst.daf.persistence.Butler`, read-only).

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -52,6 +52,22 @@ def patchApPipe(method):
     return wrapper
 
 
+class InitRecordingMock(unittest.mock.MagicMock):
+    """A MagicMock for classes that records requests for objects of that class.
+
+    Because ``__init__`` cannot be mocked directly, the calls cannot be
+    identified with the usual ``object.method`` syntax. Instead, filter the
+    object's calls for a ``name`` attribute equal to ``__init__``.
+    """
+    def __call__(self, *args, **kwargs):
+        # super() unsafe because MagicMock does not guarantee support
+        instance = unittest.mock.MagicMock.__call__(self, *args, **kwargs)
+        initCall = unittest.mock.call(*args, **kwargs)
+        initCall.name = "__init__"
+        instance.mock_calls.append(initCall)
+        return instance
+
+
 class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
     def setUp(self):
         self._testDir = tempfile.mkdtemp()
@@ -179,16 +195,9 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
         configFile = os.path.join(self.workspace.configDir, "apPipe.py")
         with open(configFile, "w") as f:
             # Illegal value; would never be set by a real config
-            f.write("config.differencer.doWriteSources = False")
+            f.write("config.differencer.doWriteSources = False\n")
+            f.write("config.associator.level1_db.db_name = ':memory:'\n")
 
-        class InitRecordingMock(unittest.mock.MagicMock):
-            def __call__(self, *args, **kwargs):
-                # super() unsafe because MagicMock does not guarantee support
-                instance = unittest.mock.MagicMock.__call__(self, *args, **kwargs)
-                initCall = unittest.mock.call(*args, **kwargs)
-                initCall.name = "__init__"
-                instance.mock_calls.append(initCall)
-                return instance
         task = self.setUpMockPatch("lsst.ap.pipe.ApPipeTask",
                                    spec=True,
                                    new_callable=InitRecordingMock,
@@ -202,6 +211,24 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
             self.assertIn("config", kwargs)
             taskConfig = kwargs["config"]
             self.assertFalse(taskConfig.differencer.doWriteSources)
+            self.assertNotEqual(taskConfig.associator.level1_db.db_name, self.workspace.dbLocation)
+
+    def testRunApPipeWorkspaceDb(self):
+        """Test that runApPipe places a database in the workspace location by default.
+        """
+        task = self.setUpMockPatch("lsst.ap.pipe.ApPipeTask",
+                                   spec=True,
+                                   new_callable=InitRecordingMock,
+                                   _DefaultName=ApPipeTask._DefaultName,
+                                   ConfigClass=ApPipeTask.ConfigClass).return_value
+
+        pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
+        initCalls = (c for c in task.mock_calls if c.name == "__init__")
+        for call in initCalls:
+            kwargs = call[2]
+            self.assertIn("config", kwargs)
+            taskConfig = kwargs["config"]
+            self.assertEqual(taskConfig.associator.level1_db.db_name, self.workspace.dbLocation)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -118,7 +118,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
         self.addCleanup(patcher.stop)
         return mock
 
-    # Mock up ApPipeTask to avoid doing any processing. _getConfig patch may be unneccessary after DM-13602
+    # Mock up ApPipeTask to avoid doing any processing.
     @unittest.mock.patch("lsst.ap.verify.pipeline_driver._getConfig", return_value=None)
     @patchApPipe
     def testRunApPipeReturn(self, _mockConfig, mockClass):
@@ -131,7 +131,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(len(metadata.paramNames(topLevelOnly=False)), 1)
         self.assertEqual(metadata.getScalar("lsst.ap.pipe.ccdProcessor.cycleCount"), 42)
 
-    # Mock up ApPipeTask to avoid doing any processing. _getConfig patch may be unneccessary after DM-13602
+    # Mock up ApPipeTask to avoid doing any processing.
     @unittest.mock.patch("lsst.ap.verify.pipeline_driver._getConfig", return_value=None)
     @patchApPipe
     def testRunApPipeSteps(self, _mockConfig, mockClass):
@@ -168,7 +168,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
 
         self.assertEqual(self.job.measurements, self.subtaskJob.measurements)
 
-    # Mock up ApPipeTask to avoid doing any processing. _getConfig patch may be unneccessary after DM-13602
+    # Mock up ApPipeTask to avoid doing any processing.
     @unittest.mock.patch("lsst.ap.verify.pipeline_driver._getConfig", return_value=None)
     @patchApPipe
     def testUpdateMetricsOnError(self, _mockConfig, mockClass):


### PR DESCRIPTION
This PR makes the association database an explicit part of the `ap_verify` workspace. It also fills the `ApPipeConfig` as required by lsst-dm/ap_pipe#29.