### PR TITLE
DM-14849: Metadata-based metrics not measured

### DIFF
--- a/config/dataset_config.yaml
+++ b/config/dataset_config.yaml
@@ -3,15 +3,15 @@ datasets:
     HiTS2015: ap_verify_hits2015
 measurements:
     timing:
-        processCcd: pipe_tasks.ProcessCcdTime
-        processCcd:isr: ip_isr.IsrTime
-        processCcd:charImage: pipe_tasks.CharacterizeImageTime
-        processCcd:calibrate: pipe_tasks.CalibrateTime
-        imageDifference: pipe_tasks.ImageDifferenceTime
-        imageDifference:astrometer: meas_astrom.AstrometryTime
-        imageDifference:register: pipe_tasks.RegisterImageTime
-        imageDifference:subtract: ip_diffim.ImagePsfMatchTime
-        imageDifference:detection: meas_algorithms.SourceDetectionTime
-        imageDifference:measurement: ip_diffim.DipoleFitTime
-        association: ap_association.AssociationTime
+        apPipe:ccdProcessor: pipe_tasks.ProcessCcdTime
+        apPipe:ccdProcessor:isr: ip_isr.IsrTime
+        apPipe:ccdProcessor:charImage: pipe_tasks.CharacterizeImageTime
+        apPipe:ccdProcessor:calibrate: pipe_tasks.CalibrateTime
+        apPipe:differencer: pipe_tasks.ImageDifferenceTime
+        apPipe:differencer:astrometer: meas_astrom.AstrometryTime
+        apPipe:differencer:register: pipe_tasks.RegisterImageTime
+        apPipe:differencer:subtract: ip_diffim.ImagePsfMatchTime
+        apPipe:differencer:detection: meas_algorithms.SourceDetectionTime
+        apPipe:differencer:measurement: ip_diffim.DipoleFitTime
+        apPipe:associator: ap_association.AssociationTime
 ...

--- a/python/lsst/ap/verify/measurements/association.py
+++ b/python/lsst/ap/verify/measurements/association.py
@@ -58,10 +58,10 @@ def measureNumberNewDiaObjects(metadata, taskName, metricName):
         a value of `metricName`, or `None` if the object counts for
         `taskName` are not present in `metadata`
     """
-    if not metadata.exists("association.numNewDiaObjects"):
+    if not metadata.exists("%s.numNewDiaObjects" % taskName):
         return None
 
-    nNew = metadata.getAsInt("association.numNewDiaObjects")
+    nNew = metadata.getAsInt("%s.numNewDiaObjects" % taskName)
     meas = lsst.verify.Measurement(metricName, nNew * u.count)
     return meas
 
@@ -90,11 +90,10 @@ def measureNumberUnassociatedDiaObjects(metadata, taskName, metricName):
         a value for `metricName`, or `None` if the object counts for
         `taskName` are not present in `metadata`
     """
-    if not metadata.exists("association.numUnassociatedDiaObjects"):
+    if not metadata.exists("%s.numUnassociatedDiaObjects" % taskName):
         return None
 
-    nUnassociated = metadata.getAsInt(
-        "association.numUnassociatedDiaObjects")
+    nUnassociated = metadata.getAsInt("%s.numUnassociatedDiaObjects" % taskName)
     meas = lsst.verify.Measurement(metricName, nUnassociated * u.count)
     return meas
 
@@ -123,13 +122,12 @@ def measureFractionUpdatedDiaObjects(metadata, taskName, metricName):
         a value for `metricName`, or `None` if the object counts for
         `taskName` are not present in `metadata`
     """
-    if not metadata.exists("association.numUpdatedDiaObjects") or \
-       not metadata.exists("association.numUnassociatedDiaObjects"):
+    if not metadata.exists("%s.numUpdatedDiaObjects" % taskName) or \
+       not metadata.exists("%s.numUnassociatedDiaObjects" % taskName):
         return None
 
-    nUpdated = metadata.getAsDouble("association.numUpdatedDiaObjects")
-    nUnassociated = metadata.getAsDouble(
-        "association.numUnassociatedDiaObjects")
+    nUpdated = metadata.getAsDouble("%s.numUpdatedDiaObjects" % taskName)
+    nUnassociated = metadata.getAsDouble("%s.numUnassociatedDiaObjects" % taskName)
     if nUpdated <= 0. or nUnassociated <= 0.:
         return lsst.verify.Measurement(metricName, 0. * u.dimensionless_unscaled)
     meas = lsst.verify.Measurement(

--- a/python/lsst/ap/verify/measurements/compute_metrics.py
+++ b/python/lsst/ap/verify/measurements/compute_metrics.py
@@ -76,15 +76,15 @@ def measureFromMetadata(metadata):
             result.append(measurement)
 
     measurement = measureNumberNewDiaObjects(
-        metadata, 'association', 'association.numNewDiaObjects')
+        metadata, 'apPipe:associator', 'association.numNewDiaObjects')
     if measurement is not None:
         result.append(measurement)
     measurement = measureFractionUpdatedDiaObjects(
-        metadata, 'association', 'association.fracUpdatedDiaObjects')
+        metadata, 'apPipe:associator', 'association.fracUpdatedDiaObjects')
     if measurement is not None:
         result.append(measurement)
     measurement = measureNumberUnassociatedDiaObjects(
-        metadata, 'association', 'association.numUnassociatedDiaObjects')
+        metadata, 'apPipe:associator', 'association.numUnassociatedDiaObjects')
     if measurement is not None:
         result.append(measurement)
     return result


### PR DESCRIPTION
This PR fixes a systematic error in the metadata keys being used by the `ap.verify.measurements` package (the keys did not get updated when `ap_pipe` was turned into a task). It also broadens the runtime measurer for forward-compatibility with DM-2639.