### PR TITLE
DM-15138: Incorrect instructions in ap_verify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,12 @@
 # lsst.ap.verify
 
-This package manages end-to-end testing and metric generation for the LSST DM Alert Production pipeline. Metrics are tested against both project- and lower-level requirements, and will be deliverable to the SQuaSH metrics service.
+`ap_verify` is a package to be added to the [LSST Science Pipelines](https://pipelines.lsst.io/).
 
-`ap_verify` is part of the LSST Science Pipelines. You can learn how to install the Pipelines at https://pipelines.lsst.io/install/index.html.
+This package manages end-to-end testing and metric generation for the [LSST DM Alert Production pipeline](https://github.com/lsst-dm/ap_pipe/).
+Metrics are tested against both project- and lower-level requirements, and will be deliverable to the SQuaSH metrics service.
 
-## Configuration
+`ap_verify` is designed to work on downloadable Git LFS datasets, which must be installed separately.
+Unlike the Alert Production pipeline itself, it cannot be run on generic data repositories.
 
-`ap_verify` is configured from `config/dataset_config.yaml`. The file currently must have:
-
-* a dictionary named `datasets`, which maps from user-visible dataset names to the eups package that implements them (see `Setting Up a Dataset`, below)
-* a dictionary named `measurements`, which contains dictionaries needed for different metrics:
-    * `timing`: maps from Tasks or subTasks to the names of metrics that time them. The names of subTasks must be those assigned by the parent Task, and may be prefixed by the parent Task name(s) followed by a colon, as in "imageDifference:detection". Metric names must exist in `verify_metrics` and include the package they're associated with, as in "meas_algorithms.SourceDetectionTime".
-
-Other configuration options may be added in the future.
-
-### Setting Up a Dataset
-
-`ap_verify` requires that all data be in a [dataset package](https://github.com/lsst-dm/ap_verify_dataset_template). It will create a workspace modeled after the package's `repo` directory, then process any data found in the `raw` and `ref_cats` in the new workspace.
-
-`ap_verify` can be built without installing any datasets, although [ap_verify_testdata](https://github.com/lsst-dm/ap_verify_testdata/) is needed to test dataset support.
-
-The dataset package must work with eups, and must be registered in `config/dataset_config.yaml` in order for `ap_verify` to support it. `ap_verify` will use `eups setup` to prepare the dataset package and any dependencies; typically, they will include the `obs_` package for the instrument that took the data.
-
-## Running ap_verify
-
-A basic run on HiTS data:
-
-    python python/lsst/ap/verify/ap_verify.py --dataset HiTS2015 --output workspace/hits/ --dataIdString "visit=54123"
-
-This will create a workspace (a Butler repository) in `workspace/hits` based on `<hits-data>/data/`, ingest the HiTS data into it, then run visit 54123 through the entire AP pipeline.
-
-### Optional Arguments
-
-`--silent`: Normally, `ap_verify` submits measurements to SQuaSH for quality tracking. This argument disables reporting for test runs. `ap_verify` will dump measurements to `ap_verify.verify.json` regardless of whether this flag is set.
-
-`-j, --processes`: Specify a particular degree of parallelism. Like in Tasks, this argument may be taken at face value with no intelligent thread management.
-
-`-h, --help, --version`: These arguments print a brief usage guide and the program version, respectively.
+For more details, including user instructions and information about supported datasets, consult the [package documentation](https://github.com/lsst-dm/ap_verify/tree/master/doc/lsst.ap.verify).
+When `ap_verify` is formally added to the LSST Stack this documentation will be available through the [Science Pipelines](https://pipelines.lsst.io/) documentation.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -29,12 +29,12 @@ Using the :ref:`HiTS 2015 <ap_verify_hits2015-package>` dataset as an example, o
 
 .. prompt:: bash
 
-   ap_verify.py --dataset HiTS2015 --id "visit=54123 ccdnum=25 filter=g" --output workspaces/hits/ --silent
+   ap_verify.py --dataset HiTS2015 --id "visit=412518 ccdnum=25 filter=g" --output workspaces/hits/ --silent
 
 Here the inputs are:
 
 * :command:`HiTS2015` is the :ref:`dataset name <ap-verify-dataset-name>`,
-* :command:`visit=54123 ccdnum=25 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
+* :command:`visit=412518 ccdnum=25 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
 
 while the output is:
 
@@ -42,7 +42,7 @@ while the output is:
 
 * :command:`--silent` disables SQuaSH metrics reporting.
 
-This call will create a new directory at :file:`workspaces/hits`, ingest the HiTS data into a new repository based on :file:`<hits-data>/repo/`, then run visit 54123 through the entire AP pipeline.
+This call will create a new directory at :file:`workspaces/hits`, ingest the HiTS data into a new repository based on :file:`<hits-data>/repo/`, then run visit 412518 through the entire AP pipeline.
 
 .. note::
 


### PR DESCRIPTION
This PR updates the readme to use the modern boilerplate (from [templates](https://github.com/lsst/templates/blob/master/project_templates/stack_package/example_pythononly/README.rst)) and one-sentence-per-line formatting style, plus a brief explanation that `ap_verify` cannot be used by itself (since the dataset system is a significant deviation from normal Stack idioms). The old usage information is deferred to the documentation.

This PR also fixes some misleading text in the command-line examples.